### PR TITLE
[NSA-7586] Approver BCC email address fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,6 @@
     "max-len": 0
   },
   "env": {
-    "jest/globals": true
+    "jest": true
   }
 }

--- a/lib/infrastructure/email/SESEmailAdapter.js
+++ b/lib/infrastructure/email/SESEmailAdapter.js
@@ -1,13 +1,15 @@
-const EmailAdapter = require('./EmailAdapter');
 const aws = require('aws-sdk');
+const EmailAdapter = require('./EmailAdapter');
 const emailUtils = require('./utils');
 
 const addContentType = (name, body, contentTypes) => {
-  const type = contentTypes.find(item => item.type.toLowerCase() === name.toLowerCase());
+  const type = contentTypes.find((item) => item.type.toLowerCase() === name.toLowerCase());
   if (!type) {
     return;
   }
 
+  // Disable rule, as this function is expected to assign fields to "body".
+  // eslint-disable-next-line no-param-reassign
   body[name] = {
     Data: type.content,
     Charset: 'UTF-8',
@@ -24,32 +26,32 @@ class SESEmailAdapter extends EmailAdapter {
 
     const awsConfig = {};
     if (config.notifications.email.params && config.notifications.email.params.accessKey) {
-      awsConfig['accessKeyId'] = config.notifications.email.params.accessKey;
+      awsConfig.accessKeyId = config.notifications.email.params.accessKey;
     } else {
-      this.logger.info('SESEmailAdapter- accessKeyId is missing')
+      this.logger.info('SESEmailAdapter- accessKeyId is missing');
     }
     if (config.notifications.email.params && config.notifications.email.params.accessSecret) {
-      awsConfig['secretAccessKey'] = config.notifications.email.params.accessSecret;
-    }else {
-      this.logger.info('SESEmailAdapter- secretAccessKey is missing')
+      awsConfig.secretAccessKey = config.notifications.email.params.accessSecret;
+    } else {
+      this.logger.info('SESEmailAdapter- secretAccessKey is missing');
     }
     if (config.notifications.email.params && config.notifications.email.params.region) {
-      awsConfig['region'] = config.notifications.email.params.region;
-    }else {
-      this.logger.info('SESEmailAdapter- region is missing')
+      awsConfig.region = config.notifications.email.params.region;
+    } else {
+      this.logger.info('SESEmailAdapter- region is missing');
     }
 
     aws.config.update(awsConfig);
   }
 
-  async send(recipient, template, data, subject, bccRecipient) {
+  async send(recipient, template, data, subject, bccRecipients) {
     try {
       const contentTypes = await emailUtils.renderEmailContent(template, data);
 
       return new Promise((resolve, reject) => {
-        var ses = new aws.SES();
+        const ses = new aws.SES();
 
-        var body = {};
+        const body = {};
         addContentType('Html', body, contentTypes);
         addContentType('Text', body, contentTypes);
 
@@ -57,16 +59,16 @@ class SESEmailAdapter extends EmailAdapter {
           Source: this.sender,
           Destination: {
             ToAddresses: [recipient],
-            BccAddresses: [bccRecipient]
+            BccAddresses: [bccRecipients],
           },
           Message: {
             Subject: {
               Data: subject,
-              Charset: 'UTF-8'
+              Charset: 'UTF-8',
             },
-            Body: body
+            Body: body,
           },
-          ReturnPath: this.returnEmail
+          ReturnPath: this.returnEmail,
         }, (err) => {
           if (err) {
             this.logger.error(`Error sending ses email - ${JSON.stringify(err)}`);
@@ -79,9 +81,8 @@ class SESEmailAdapter extends EmailAdapter {
       });
     } catch (e) {
       this.logger.error(`Error sending ses email- outer catch block - ${JSON.stringify(e)}`);
-      return Promise.reject(`Error sending ses email- outer catch block - ${JSON.stringify(e)}`);
+      return Promise.reject(new Error(`Error sending ses email- outer catch block - ${JSON.stringify(e)}`));
     }
-
   }
 }
 

--- a/lib/infrastructure/email/SESEmailAdapter.js
+++ b/lib/infrastructure/email/SESEmailAdapter.js
@@ -44,12 +44,31 @@ class SESEmailAdapter extends EmailAdapter {
     aws.config.update(awsConfig);
   }
 
+  /**
+   * Renders the email content using the specified template and data,
+   * and sends the email using the specified recipient, bccRecipients and subject.
+   *
+   * @param {string} recipient Recipient's email address.
+   * @param {string} template Template name for the email content (defined in ../templates/renderTemplates).
+   * @param {Object} data Data object containing information to be used in the template.
+   * @param {string} subject Email subject.
+   * @param {string|string[]} [bccRecipients=[]] BCC recipient list, or a single BCC recipient.
+   * @returns {Promise<Error|undefined>} An empty Promise when fulfilled, or an Error on rejection.
+   */
   async send(recipient, template, data, subject, bccRecipients) {
     try {
       const contentTypes = await emailUtils.renderEmailContent(template, data);
 
       return new Promise((resolve, reject) => {
         const ses = new aws.SES();
+
+        // Format bccRecipients, setting a default and turning a single recipient into an array.
+        let bccAddressList = [];
+        if (Array.isArray(bccRecipients)) {
+          bccAddressList = bccRecipients;
+        } else if (typeof bccRecipients === 'string') {
+          bccAddressList = [bccRecipients];
+        }
 
         const body = {};
         addContentType('Html', body, contentTypes);
@@ -59,7 +78,7 @@ class SESEmailAdapter extends EmailAdapter {
           Source: this.sender,
           Destination: {
             ToAddresses: [recipient],
-            BccAddresses: [bccRecipients],
+            BccAddresses: bccAddressList,
           },
           Message: {
             Subject: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.notification.jobs",
-  "version": "6.2.5",
+  "version": "6.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.notification.jobs",
-      "version": "6.2.5",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.279.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.notification.jobs",
-  "version": "6.2.5",
+  "version": "6.3.1",
   "description": "Job handlers for notifications",
   "main": "lib/index.js",
   "scripts": {

--- a/test/handlers/invitationTests/newUserInvitationV2.test.js
+++ b/test/handlers/invitationTests/newUserInvitationV2.test.js
@@ -66,7 +66,7 @@ describe('when sending v2 user invitation', () => {
     await handler.processor(data);
 
     expect(send.mock.calls).toHaveLength(1);
-    expect(send.mock.calls[0][3]).toBe(`You’ve been invited to join ${data.serviceName}`);
+    expect(send.mock.calls[0][3]).toBe('You’ve been invited to join DfE Sign-in');
   });
 
   it('then it should use register subject line if not self invoked', async () => {

--- a/test/handlers/invitationTests/newUserInvitationV2.test.js
+++ b/test/handlers/invitationTests/newUserInvitationV2.test.js
@@ -1,7 +1,7 @@
 jest.mock('./../../../lib/infrastructure/email');
 
-const { getEmailAdapter } = require('./../../../lib/infrastructure/email');
-const { getHandler } = require('./../../../lib/handlers/invite/newUserInvitationV2');
+const { getEmailAdapter } = require('../../../lib/infrastructure/email');
+const { getHandler } = require('../../../lib/handlers/invite/newUserInvitationV2');
 
 const send = jest.fn();
 const logger = {
@@ -39,10 +39,9 @@ describe('when sending v2 user invitation', () => {
       getmoreinfoUrl: `${config.notifications.helpUrl}/moving-to-DfE-Sign-in`,
       code: 'ABC123',
       isApprover: false,
-      orgName:"Test Org",
-      approverEmail: "test@test.com",
+      orgName: 'Test Org',
+      approverEmail: 'test@test.com',
       source: 'source-location',
-
     };
 
     handler = getHandler(config, logger);
@@ -79,12 +78,12 @@ describe('when sending v2 user invitation', () => {
   });
 
   it('then it should use override subject line if one is present', async () => {
-    data.overrides = {subject: "HELLO WORLD"};
+    data.overrides = { subject: 'HELLO WORLD' };
 
     await handler.processor(data);
 
     expect(send.mock.calls).toHaveLength(1);
-    expect(send.mock.calls[0][3]).toBe("HELLO WORLD");
+    expect(send.mock.calls[0][3]).toBe('HELLO WORLD');
   });
 
   it('then it should add html version of override body if one is present', async () => {
@@ -95,7 +94,7 @@ describe('when sending v2 user invitation', () => {
     await handler.processor(data);
 
     expect(send.mock.calls).toHaveLength(1);
-    expect(send.mock.calls[0][2].overrides.htmlBody).toBe("<h1>This is a test</h1>\n\n<p>It should <em>ignore</em> the formatting in <em>here</em></p>");
+    expect(send.mock.calls[0][2].overrides.htmlBody).toBe('<h1>This is a test</h1>\n\n<p>It should <em>ignore</em> the formatting in <em>here</em></p>');
   });
 
   it('then it should add a plain text version of override body if one is present', async () => {
@@ -106,25 +105,23 @@ describe('when sending v2 user invitation', () => {
     await handler.processor(data);
 
     expect(send.mock.calls).toHaveLength(1);
-    expect(send.mock.calls[0][2].overrides.textBody).toBe("This is a test\nIt should ignore the formatting in here");
+    expect(send.mock.calls[0][2].overrides.textBody).toBe('This is a test\nIt should ignore the formatting in here');
   });
 
   it('then it should send email using template data', async () => {
     await handler.processor(data);
 
     expect(send.mock.calls).toHaveLength(1);
-  
+
     expect(send.mock.calls[0][2]).toEqual({
       approverEmail: data.approverEmail,
       firstName: data.firstName,
-      approverEmail: 'test@test.com',
       lastName: data.lastName,
       serviceName: data.serviceName,
       requiresDigipass: data.requiresDigipass,
       selfInvoked: data.selfInvoked,
       code: data.code,
       getmoreinfoUrl: 'https://help.test/moving-to-DfE-Sign-in',
-      source: 'source-location',
       helpUrl: `${config.notifications.helpUrl}/contact-us`,
       isApprover: data.isApprover,
       orgName: data.orgName,

--- a/test/infrastructure/emailtests/SESEmailAdapter.test.js
+++ b/test/infrastructure/emailtests/SESEmailAdapter.test.js
@@ -109,16 +109,13 @@ describe('When sending an email using SES', () => {
     expect(awsSESSendEmail.mock.calls[0][0].Message.Body.Text.Data).toBe('some plain text');
   });
 
-  it('then it should throw an error if sending fails', async () => {
+  it('then it should reject with an error if sending fails', async () => {
     awsSESSendEmail.mockImplementation((_, done) => {
       done('test error');
     });
 
-    try {
+    await expect(async () => {
       await adapter.send(recipient, template, data, subject);
-      throw new Error('No error thrown');
-    } catch (e) {
-      expect(e).toBe('test error');
-    }
+    }).rejects.toBe('test error');
   });
 });


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-7586

This PR addresses an issue where an array of email addresses, such as for organisation requests, are passed as the BCC emails for the Amazon SES service. A previous change caused them to become a two-dimensional array instead of just being passed as is, [creating this error](https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/ComponentId~/%7B%22SubscriptionId%22%3A%22a8736e42-ebd4-4459-a73c-54b2137562ba%22%2C%22ResourceGroup%22%3A%22s141p01-shd%22%2C%22Name%22%3A%22s141p01-signin-shd-ai%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252Fa8736e42-ebd4-4459-a73c-54b2137562ba%252FresourceGroups%252Fs141p01-shd%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fs141p01-signin-shd-ai%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel~/%7B%22eventId%22%3A%229ad175f0-8f9f-11ee-8bc2-000d3aac87a0%22%2C%22timestamp%22%3A%222023-11-30T16%3A42%3A58.074Z%22%2C%22cacheId%22%3A%227b34d4f2-f4e1-4676-9788-75339940dd9d%22%2C%22eventTable%22%3A%22exceptions%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A1800000%2C%22endTime%22%3A%222023-11-30T16%3A58%3A17.046Z%22%7D%7D), so this change does the following:

- Enables ESLint by updating the env to be "jest" as "jest/globals" stops all ESLint messages from appearing in newer versions.
- Adds a JSDoc/docblock comment to the send email function in the `SESEmailAdapter` class, so future devs know that a string or an array can be passed for BCC addresses.
- Formats the BCC recipients passed into the send email function, if none are passed then an empty array is given, if a string is passed than a single element array is given, and if an array is passed then it is given as-is.
- Added additional unit tests for the BCC addresses, to ensure it handles the above scenarios.
- Updated a test for invitation emails, that was failing due to a previous update, as the functionality is working correctly, the test just hadn't been updated.
- ESLint fixes across modified files.
- Updated version to 6.3.1