### PR TITLE
Update package dependencies to resolve vulnerability issues (DSI-6983)

### DIFF
--- a/lib/handlers/invite/newUserInvitationV2.js
+++ b/lib/handlers/invite/newUserInvitationV2.js
@@ -31,8 +31,12 @@ function getTokenTextNewLine(token){
   return (token.type === 'heading' || token.type === 'paragraph') ? '\n' : ''
 }
 
-//Its possible that 'marked' will HTML encode strings. For example, the word [You've] would be
-//encoded as [You&#39;ve] and appear as such in plain. decodeHtmlEntities attempts to resolve this.
+//Its possible that 'marked' will HTML encode strings. For example, the word [You've] will be
+//encoded as [You&#39;ve]. decodeHtmlEntities attempts to resolve this. Interstingly, this
+//'issue' only happens with token.tokens leafs, and not the parent i.e. token.text = You've
+//but a leaf will be token.tokens[0] = You&#39;ve  However, if you take the parent token.text
+//you run into cases where it'll contain markdown i.e. "You've *ignore*" where-as the leaf
+//will be token.tokens[0] = "You&#39;ve ignore"
 const decodeHtmlEntities = (str) => {
   const htmlEntities = {
       '&amp;': '&',

--- a/lib/handlers/invite/newUserInvitationV2.js
+++ b/lib/handlers/invite/newUserInvitationV2.js
@@ -1,25 +1,57 @@
 const { getEmailAdapter } = require('./../../infrastructure/email');
 const {marked} = require('marked')
 
-//Convert tokens provided by the marked lexer into text.  Iterated 'tokens' looking for a property 'text'. 
-//In this instance 'text' is the text representation of the markdown (MD) without formatting 
-//(property 'raw' contains MD).  Some tokens don't have the 'text' property but do have 'type' 
-//with a value of 'space' which represents '\n\n' - therefore use these.
-const parseMarkdownTreeToText = (tokens) => {
+//tokens provided by the 'marked' lexer will be iterated.  For any given token
+//it might have a property 'tokens' i.e. 'token.tokens' which if present is
+//used.  The reason being is that token.text can return encoded markdown,
+//where-as, if you iterate token.tokens you get the plain text version.
+//In all cases then use the token.text where the token.type matches.
+function parseMarkdownTreeToText(tokens) {
   let text = '';
   for (const token of tokens) {
-    if ('text' in token) {
-      text += token.text;
-    } else if ('type' in token && token.type == 'space' && 'raw' in token){
-      text += token.raw
+    if (token.tokens){
+      text += parseMarkdownTreeToText(token.tokens);
+      text += getTokenTextNewLine(token);
+    }
+    else {
+      if (token.type === 'text' || token.type === 'paragraph' || token.type === 'heading' || token.type === 'code') {
+        text += decodeHtmlEntities(token.text);
+        text += getTokenTextNewLine(token);
+      }
+      else if (token.type === 'space'){
+        text += token.raw;
+      }
     }
   }
   return text;
+}
+
+//Certain token types need to append a new line.
+function getTokenTextNewLine(token){
+  return (token.type === 'heading' || token.type === 'paragraph') ? '\n' : ''
+}
+
+//Its possible that 'marked' will HTML encode strings. For example, the word [You've] would be
+//encoded as [You&#39;ve] and appear as such in plain. decodeHtmlEntities attempts to resolve this.
+const decodeHtmlEntities = (str) => {
+  const htmlEntities = {
+      '&amp;': '&',
+      '&lt;': '<',
+      '&gt;': '>',
+      '&quot;': '"',
+      '&#39;': "'",
+      '&#x27;': "'",
+      '&#x2F;': '/',
+      '&#x5C;': '\\',
+      '&#96;': '`',
+  };
+
+  return str.replace(/&[#A-Za-z0-9]+;/g, (entity) => htmlEntities[entity] || entity);
 };
 
 const convertMarkdownToText = (content) => {
-  const tree = markdown.parse(content);
-  return parseMarkdownTreeToText(tree);
+  const tokens = marked.lexer(content);
+  return parseMarkdownTreeToText(tokens);
 };
 
 const convertMarkdownToHtml = (content) => {

--- a/lib/handlers/invite/newUserInvitationV2.js
+++ b/lib/handlers/invite/newUserInvitationV2.js
@@ -1,26 +1,29 @@
 const { getEmailAdapter } = require('./../../infrastructure/email');
-const { markdown } = require('markdown');
+const {marked} = require('marked')
 
-const parseMarkdownTreeToText = (element) => {
+//Convert tokens provided by the marked lexer into text.  Iterated 'tokens' looking for a property 'text'. 
+//In this instance 'text' is the text representation of the markdown (MD) without formatting 
+//(property 'raw' contains MD).  Some tokens don't have the 'text' property but do have 'type' 
+//with a value of 'space' which represents '\n\n' - therefore use these.
+const parseMarkdownTreeToText = (tokens) => {
   let text = '';
-  for (let i = 1; i < element.length; i++) {
-    if (Array.isArray(element[i])) {
-      text += parseMarkdownTreeToText(element[i]);
-    } else if (!(typeof(element[i]) === 'object')) {
-      text += element[i];
+  for (const token of tokens) {
+    if ('text' in token) {
+      text += token.text;
+    } else if ('type' in token && token.type == 'space' && 'raw' in token){
+      text += token.raw
     }
-  }
-  if (element[0] === 'para' || element[0] === 'header') {
-    text += '\n';
   }
   return text;
 };
+
 const convertMarkdownToText = (content) => {
   const tree = markdown.parse(content);
   return parseMarkdownTreeToText(tree);
 };
+
 const convertMarkdownToHtml = (content) => {
-  return markdown.toHTML(content);
+  return marked.parse(content).trim();
 };
 
 const process = async (config, logger, data) => {

--- a/lib/handlers/invite/newUserInvitationV2.js
+++ b/lib/handlers/invite/newUserInvitationV2.js
@@ -1,42 +1,9 @@
 const { getEmailAdapter } = require('./../../infrastructure/email');
 const {marked} = require('marked')
 
-//tokens provided by the 'marked' lexer will be iterated.  For any given token
-//it might have a property 'tokens' i.e. 'token.tokens' which if present is
-//used.  The reason being is that token.text can return encoded markdown,
-//where-as, if you iterate token.tokens you get the plain text version.
-//In all cases then use the token.text where the token.type matches.
-function parseMarkdownTreeToText(tokens) {
-  let text = '';
-  for (const token of tokens) {
-    if (token.tokens){
-      text += parseMarkdownTreeToText(token.tokens);
-      text += getTokenTextNewLine(token);
-    }
-    else {
-      if (token.type === 'text' || token.type === 'paragraph' || token.type === 'heading' || token.type === 'code') {
-        text += decodeHtmlEntities(token.text);
-        text += getTokenTextNewLine(token);
-      }
-      else if (token.type === 'space'){
-        text += token.raw;
-      }
-    }
-  }
-  return text;
-}
-
-//Certain token types need to append a new line.
-function getTokenTextNewLine(token){
-  return (token.type === 'heading' || token.type === 'paragraph') ? '\n' : ''
-}
 
 //Its possible that 'marked' will HTML encode strings. For example, the word [You've] will be
-//encoded as [You&#39;ve]. decodeHtmlEntities attempts to resolve this. Interstingly, this
-//'issue' only happens with token.tokens leafs, and not the parent i.e. token.text = You've
-//but a leaf will be token.tokens[0] = You&#39;ve  However, if you take the parent token.text
-//you run into cases where it'll contain markdown i.e. "You've *ignore*" where-as the leaf
-//will be token.tokens[0] = "You&#39;ve ignore"
+//encoded as [You&#39;ve]. decodeHtmlEntities attempts to resolve this.
 const decodeHtmlEntities = (str) => {
   const htmlEntities = {
       '&amp;': '&',
@@ -53,13 +20,13 @@ const decodeHtmlEntities = (str) => {
   return str.replace(/&[#A-Za-z0-9]+;/g, (entity) => htmlEntities[entity] || entity);
 };
 
-const convertMarkdownToText = (content) => {
-  const tokens = marked.lexer(content);
-  return parseMarkdownTreeToText(tokens);
-};
-
 const convertMarkdownToHtml = (content) => {
   return marked.parse(content).trim();
+};
+
+const convertMarkdownToText = (content) => {
+  const html = convertMarkdownToHtml(content);
+  return decodeHtmlEntities(html.replace(/<[^>]+?>/g, ""));
 };
 
 const process = async (config, logger, data) => {

--- a/lib/infrastructure/ApiClient.js
+++ b/lib/infrastructure/ApiClient.js
@@ -1,5 +1,5 @@
 const jwtStrategy = require('login.dfe.jwt-strategies');
-const rp = require('login.dfe.request-promise-retry');
+const { fetchApi } = require('login.dfe.async-retry');
 
 class ApiClient {
   constructor(opts, correlationId) {
@@ -22,15 +22,13 @@ class ApiClient {
       : `${this.opts.url}${resource}`;
 
     try {
-      return await rp({
+      return await fetchApi(uri, {
         method,
-        uri,
         headers: {
           'x-correlation-id': this.correlationId,
           'authorization': `bearer ${this.token}`,
         },
-        body,
-        json: true,
+        body
       })
     } catch (e) {
       const status = e.statusCode || 500;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1642,14 +1642,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha1-dWZBrbWHhRtcyz4JXa8nrlgchAY="
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha1-oTN8pCaqYc75/hW1so40CnL2+pk=",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/abbrev/-/abbrev-1.1.1.tgz",
@@ -1684,40 +1676,6 @@
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/adal-node": {
-      "version": "0.2.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/adal-node/-/adal-node-0.2.4.tgz",
-      "integrity": "sha1-iBvu2dSTt2qGcGrVyNxvYO/wRSA=",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.3",
-        "async": "^2.6.3",
-        "axios": "^0.21.1",
-        "date-utils": "*",
-        "jws": "3.x.x",
-        "underscore": ">= 1.3.1",
-        "uuid": "^3.1.0",
-        "xpath.js": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.6.15"
-      }
-    },
-    "node_modules/adal-node/node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async/-/async-2.6.4.tgz",
-      "integrity": "sha1-cGt/9ghGZM1+rnE/b5ZUM7VQQiE=",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/adal-node/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/agent-base": {
@@ -1814,18 +1772,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/apparatus": {
-      "version": "0.0.10",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/apparatus/-/apparatus-0.0.10.tgz",
-      "integrity": "sha1-gep1Z3Ktp3hj21TO7oICwQm9yj4=",
-      "optional": true,
-      "dependencies": {
-        "sylvester": ">= 0.0.8"
-      },
-      "engines": {
-        "node": ">=0.2.6"
       }
     },
     "node_modules/argparse": {
@@ -2030,14 +1976,6 @@
       "integrity": "sha1-vGzPkbX/CsB7vNvxx8ThUNtNu2w=",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha1-xnuQ3AVo5cHPKwuFjEO6KOLtpXU=",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2702,14 +2640,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/date-utils": {
-      "version": "1.2.21",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/date-utils/-/date-utils-1.2.21.tgz",
-      "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=",
-      "engines": {
-        "node": ">0.4.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.4.tgz",
@@ -2873,12 +2803,6 @@
       "version": "2.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dottie/-/dottie-2.0.6.tgz",
       "integrity": "sha1-NFZOv8bsXldyJy1GZCStW2lkhNQ="
-    },
-    "node_modules/double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
-      "optional": true
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -5474,17 +5398,37 @@
       }
     },
     "node_modules/login.dfe.jwt-strategies": {
-      "version": "3.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#10a7098d6f7aff992d5903d755ba537849ae2f4b",
+      "version": "4.1.0",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#33231d6cdf373cc3c2b78b31762cbcc6143b907d",
       "dependencies": {
-        "adal-node": "^0.2.3",
-        "memory-cache": "^0.2.0"
+        "@azure/msal-node": "^2.6.4"
+      }
+    },
+    "node_modules/login.dfe.jwt-strategies/node_modules/@azure/msal-common": {
+      "version": "14.10.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.10.0.tgz",
+      "integrity": "sha1-IVRJcmcXtT1UmVPbd1YsrWy4Qhw=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/login.dfe.jwt-strategies/node_modules/@azure/msal-node": {
+      "version": "2.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.8.1.tgz",
+      "integrity": "sha1-re0o037qLnJ4yb1E8gFmRzkPI5w=",
+      "dependencies": {
+        "@azure/msal-common": "14.10.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/login.dfe.kue": {
       "name": "kue",
-      "version": "0.11.6",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.kue.git#34b29db0b31364ac932c21dffa3eeaf8607c55f3",
+      "version": "0.12.0",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.kue.git#debef8bae8e67cce4a42fee4be23a4f6bf3b7ce4",
       "dependencies": {
         "body-parser": "^1.12.2",
         "express": "^4.12.2",
@@ -5498,9 +5442,6 @@
       },
       "bin": {
         "kue-dashboard": "bin/kue-dashboard"
-      },
-      "optionalDependencies": {
-        "reds": "^1.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -5566,11 +5507,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/memory-cache": {
-      "version": "0.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/memory-cache/-/memory-cache-0.2.0.tgz",
-      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -5714,20 +5650,6 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
       "integrity": "sha1-eJkHjmS/PIo9cyYBs9QP8F21j6A="
-    },
-    "node_modules/natural": {
-      "version": "0.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/natural/-/natural-0.5.0.tgz",
-      "integrity": "sha1-Vam7aOzPXs5VNUhgBKV94mSuMYA=",
-      "optional": true,
-      "dependencies": {
-        "apparatus": ">= 0.0.9",
-        "sylvester": ">= 0.0.12",
-        "underscore": ">=1.3.1"
-      },
-      "engines": {
-        "node": ">=0.4.10"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6620,39 +6542,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/reds": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/reds/-/reds-1.0.0.tgz",
-      "integrity": "sha1-6W2zYagwLLHnXSF6AzKqtrmOH6g=",
-      "optional": true,
-      "dependencies": {
-        "natural": "0.5.0",
-        "redis": "^2.7.1"
-      }
-    },
-    "node_modules/reds/node_modules/redis": {
-      "version": "2.8.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha1-ICKI4/WMSfYHnZevehDhMDrhSwI=",
-      "optional": true,
-      "dependencies": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/reds/node_modules/redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
@@ -7384,15 +7273,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sylvester": {
-      "version": "0.0.21",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sylvester/-/sylvester-0.0.21.tgz",
-      "integrity": "sha1-KYexzivS84sNzio0OIiEv6RADqc=",
-      "optional": true,
-      "engines": {
-        "node": ">=0.2.6"
-      }
-    },
     "node_modules/tedious": {
       "version": "14.7.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-14.7.0.tgz",
@@ -7653,11 +7533,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha1-BHhqH1idxsCfdh/F9FuJ6TUTZEE="
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -7951,14 +7826,6 @@
       "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM=",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/xpath.js": {
-      "version": "1.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E=",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "ejs": "^3.1.6",
         "lodash": "^4.17.21",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
-        "login.dfe.dao": "4.2.0",
+        "login.dfe.dao": "github:DFE-Digital/login.dfe.dao#v4.2.12",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
         "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
         "marked": "^12.0.2",
@@ -231,58 +231,27 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "2.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-2.1.0.tgz",
-      "integrity": "sha1-ifC/wdEmTf09DLGYN8M6nGcG1Ug=",
+      "version": "3.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
+      "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
+        "@azure/core-auth": "^1.5.0",
         "@azure/core-client": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.1.0",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^2.26.0",
-        "@azure/msal-common": "^7.0.0",
-        "@azure/msal-node": "^1.10.0",
+        "@azure/msal-browser": "^3.5.0",
+        "@azure/msal-node": "^2.5.1",
         "events": "^3.0.0",
         "jws": "^4.0.0",
         "open": "^8.0.0",
         "stoppable": "^1.1.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
+        "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/identity/node_modules/@azure/msal-common": {
-      "version": "7.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-7.6.0.tgz",
-      "integrity": "sha1-tS6X71QCdfcmEc/1eTffoLNM3Mo=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@azure/identity/node_modules/@azure/msal-node": {
-      "version": "1.18.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
-      "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
-      "dependencies": {
-        "@azure/msal-common": "13.3.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": "10 || 12 || 14 || 16 || 18"
-      }
-    },
-    "node_modules/@azure/identity/node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
-      "engines": {
-        "node": ">=0.8.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@azure/identity/node_modules/events": {
@@ -345,20 +314,12 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "2.38.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-2.38.4.tgz",
-      "integrity": "sha1-2KBPbxZLfVk3P5n6aXdXjXlrTSg=",
+      "version": "3.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-3.15.0.tgz",
+      "integrity": "sha1-o7Ij555G24J/VAVwIaIA83Vcvfc=",
       "dependencies": {
-        "@azure/msal-common": "13.3.1"
+        "@azure/msal-common": "14.10.0"
       },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1572,14 +1533,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/es-aggregate-error": {
-      "version": "1.0.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/es-aggregate-error/-/es-aggregate-error-1.0.6.tgz",
-      "integrity": "sha1-FHLfsPsctMPyvTsqe34Z9godZsA=",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1632,6 +1585,20 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/readable-stream/-/readable-stream-4.0.14.tgz",
+      "integrity": "sha1-WnagDh491v+SHqKz+sdIXFpJLBk=",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1662,6 +1629,17 @@
       "version": "1.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha1-dWZBrbWHhRtcyz4JXa8nrlgchAY="
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -2147,13 +2125,14 @@
       ]
     },
     "node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha1-GDcV9njHGI7O+f5HXZAglABiQnM=",
+      "version": "6.0.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.12.tgz",
+      "integrity": "sha1-d8NbluE67/AoSWx5i3U4nd7px/g=",
       "dependencies": {
+        "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "readable-stream": "^4.2.0"
       }
     },
     "node_modules/bl/node_modules/buffer": {
@@ -3339,6 +3318,14 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k=",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/events": {
@@ -5329,11 +5316,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -5374,23 +5356,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
-    },
     "node_modules/login.dfe.async-retry": {
       "version": "2.0.3",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.async-retry.git#72c42369276361f6cdeaabc331100f50b4a10dbf",
@@ -5399,28 +5364,39 @@
       }
     },
     "node_modules/login.dfe.config.schema.common": {
-      "version": "1.9.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.config.schema.common.git#3c88abb30251262bb3d05622436c5da5831266cd",
+      "version": "1.9.4",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.config.schema.common.git#56d274b1a915c28faa06621e1ab1e26e953bb62b",
       "dependencies": {
-        "simpl-schema": "^1.5.6"
+        "simpl-schema": "^3.4.1"
       }
     },
     "node_modules/login.dfe.dao": {
-      "version": "4.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-4.2.0.tgz",
-      "integrity": "sha1-4hGcySeLeKbq12s4zRSuV2wbZHg=",
+      "version": "4.2.12",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.dao.git#c9171f4d7ed5d2403859f28e9653ec05e62b5b02",
       "dependencies": {
         "eslint": "^8.12.0",
         "express": "^4.17.3",
         "lodash": "^4.17.21",
-        "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v1.9.3",
-        "login.dfe.kue": "git+https://github.com/DFE-Digital/login.dfe.kue.git#v0.11.6",
+        "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v2.1.0",
+        "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
         "sequelize": "^6.17.0",
         "sequelize-mock": "^0.10.2",
-        "simpl-schema": "^1.12.0",
-        "tedious": "^14.4.0",
-        "uuid": "^8.3.2",
+        "simpl-schema": "^3.4.1",
+        "tedious": "^16.4.0",
+        "uuid": "^9.0.0",
         "verror": "^1.10.1"
+      }
+    },
+    "node_modules/login.dfe.dao/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/login.dfe.jwt-strategies": {
@@ -5523,14 +5499,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
-    },
-    "node_modules/message-box": {
-      "version": "0.2.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/message-box/-/message-box-0.2.7.tgz",
-      "integrity": "sha1-e6s0L+Cw7aJG0UkKaW6WWl55GIo=",
-      "dependencies": {
-        "lodash.template": "^4.5.0"
-      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -5642,9 +5610,13 @@
       }
     },
     "node_modules/mongo-object": {
-      "version": "0.1.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mongo-object/-/mongo-object-0.1.4.tgz",
-      "integrity": "sha1-lQ0dhWuFr18jIbgrsItnucJ/l2Y="
+      "version": "3.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mongo-object/-/mongo-object-3.0.1.tgz",
+      "integrity": "sha1-4NSjsjSBFRde0Zvr0/maErs4eYM=",
+      "engines": {
+        "node": ">=14.16",
+        "npm": ">=8"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -6228,6 +6200,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/promise": {
       "version": "7.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/promise/-/promise-7.3.1.tgz",
@@ -6472,17 +6452,69 @@
       "dev": true
     },
     "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
+      "version": "4.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha1-nn/ExFCZuu7ZNL/265e6bPJyngk=",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/readable-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha1-Ks5XhFnMj74qcKqo9S7mO2p0xsY=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/events/-/events-3.3.0.tgz",
+      "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/readable-stream/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/redis": {
       "version": "3.1.2",
@@ -6966,13 +6998,16 @@
       "dev": true
     },
     "node_modules/simpl-schema": {
-      "version": "1.13.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/simpl-schema/-/simpl-schema-1.13.1.tgz",
-      "integrity": "sha1-roVOMnJTcQlA3Aj+91hltLGS2yw=",
+      "version": "3.4.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/simpl-schema/-/simpl-schema-3.4.6.tgz",
+      "integrity": "sha1-3+v1K1yiY1AxWRXjmU/+vVFbKeY=",
       "dependencies": {
         "clone": "^2.1.2",
-        "message-box": "^0.2.7",
-        "mongo-object": "^0.1.4"
+        "mongo-object": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.16",
+        "npm": ">=8"
       }
     },
     "node_modules/sisteransi": {
@@ -7258,26 +7293,24 @@
       }
     },
     "node_modules/tedious": {
-      "version": "14.7.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-14.7.0.tgz",
-      "integrity": "sha1-QSbqtoqj8k70JAby50r1qpa2TlA=",
+      "version": "16.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.7.1.tgz",
+      "integrity": "sha1-EZDzD9maQT8dySUN7kg1zweItlA=",
       "dependencies": {
-        "@azure/identity": "^2.0.4",
+        "@azure/identity": "^3.4.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.2.0",
-        "@types/es-aggregate-error": "^1.0.2",
-        "bl": "^5.0.0",
-        "es-aggregate-error": "^1.0.8",
+        "@js-joda/core": "^5.5.3",
+        "bl": "^6.0.3",
+        "es-aggregate-error": "^1.0.9",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.0.1",
-        "punycode": "^2.1.0",
+        "node-abort-controller": "^3.1.1",
         "sprintf-js": "^1.1.2"
       },
       "engines": {
-        "node": ">=12.3.0"
+        "node": ">=16"
       }
     },
     "node_modules/tedious/node_modules/iconv-lite": {
@@ -7599,11 +7632,6 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "aws-sdk": "^2.279.1",
         "ejs": "^3.1.6",
         "lodash": "^4.17.21",
+        "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.dao": "4.2.0",
-        "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
-        "login.dfe.kue": "git+https://github.com/DFE-Digital/login.dfe.kue.git#v0.11.6",
-        "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
+        "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.0.0",
+        "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.11.6",
         "markdown": "^0.5.0",
         "notifications-node-client": "^7.0.0",
         "uuid": "^8.3.2"
@@ -31,24 +31,14 @@
         "node": "18.x.x"
       }
     },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha1-vZFUrsmYP3ezoDTsqgFcLkIB9s8=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@ampproject/remapping": {
-      "version": "2.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ampproject/remapping/-/remapping-2.2.1.tgz",
-      "integrity": "sha1-mejhGFESi4cCzVfDNoTx0PJgtjA=",
+      "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha1-7UQbb6YAByUgzhi0PSyMyMrsx/Q=",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -58,7 +48,6 @@
       "version": "1.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
       "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -67,142 +56,184 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-auth/-/core-auth-1.5.0.tgz",
-      "integrity": "sha1-pBhIxcMcs7fITECYhSZ9VaLJLkQ=",
-      "license": "MIT",
+      "version": "1.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-auth/-/core-auth-1.7.2.tgz",
+      "integrity": "sha1-VYt8t90SsAvuwHrl31kH103x69k=",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.1.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.7.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-client/-/core-client-1.7.3.tgz",
-      "integrity": "sha1-+MsqH5HovEkh+i50XP39o+bkkaM=",
-      "license": "MIT",
+      "version": "1.9.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-client/-/core-client-1.9.2.tgz",
+      "integrity": "sha1-b8ac7igWiDq2xc3WU+5PL/l3T3Q=",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.9.1",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
         "@azure/logger": "^1.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-http-compat": {
-      "version": "1.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-http-compat/-/core-http-compat-1.3.0.tgz",
-      "integrity": "sha1-vz2K4eMQED8rglUPNv0qmcm00/Q=",
-      "license": "MIT",
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-http-compat/-/core-http-compat-2.1.2.tgz",
+      "integrity": "sha1-0Vha2iS6dQ3BYdgWFpszs192Lw0=",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.4",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-client": "^1.3.0",
         "@azure/core-rest-pipeline": "^1.3.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-lro": {
-      "version": "2.5.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-lro/-/core-lro-2.5.4.tgz",
-      "integrity": "sha1-sh4ry4vZqKZS/4W2Gt7qUagFX5A=",
-      "license": "MIT",
+      "version": "2.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha1-eHEFAnog5Fx3ZRqYsBpNOwG3Wgg=",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.2.0",
         "@azure/logger": "^1.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-lro/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-paging": {
-      "version": "1.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-paging/-/core-paging-1.5.0.tgz",
-      "integrity": "sha1-WlsJNT5jYHLmp/w494eeEdCvsV8=",
-      "license": "MIT",
+      "version": "1.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha1-QNOGDcLffykdZjULLP2RcVJkM+c=",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.12.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.12.2.tgz",
-      "integrity": "sha1-qJUhZPk7Y6sVrgmqxBYTjaINrs0=",
-      "license": "MIT",
+      "version": "1.16.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz",
+      "integrity": "sha1-YxFy4v4DRs9EENHI4BrZjYSXOOI=",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.3.0",
+        "@azure/core-util": "^1.9.0",
         "@azure/logger": "^1.0.0",
-        "form-data": "^4.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0"
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-rest-pipeline/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
-      "license": "MIT",
+    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-      "integrity": "sha1-NSo4y+pDjEqDyGsxT0gBfXC6lQM=",
-      "license": "MIT",
+      "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+      "integrity": "sha1-Bl2rTgk/thiZmIoc28gn2a2QtO4=",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.6.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.6.1.tgz",
-      "integrity": "sha1-/qIhxPpDwmVDvM95m+swwceHj1o=",
-      "license": "MIT",
+      "version": "1.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.9.0.tgz",
+      "integrity": "sha1-Rpr9fmRS1TiLGJ+Q0z93VrCyENE=",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
+        "@azure/abort-controller": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/identity": {
       "version": "2.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-2.1.0.tgz",
       "integrity": "sha1-ifC/wdEmTf09DLGYN8M6nGcG1Ug=",
-      "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
@@ -229,7 +260,6 @@
       "version": "3.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/events/-/events-3.3.0.tgz",
       "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
@@ -238,7 +268,6 @@
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
-      "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -249,22 +278,20 @@
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-4.0.0.tgz",
       "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
-      "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/@azure/keyvault-keys": {
-      "version": "4.7.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/keyvault-keys/-/keyvault-keys-4.7.2.tgz",
-      "integrity": "sha1-UeuPaTq0pEgaFGHtK+WnKeZOpoQ=",
-      "license": "MIT",
+      "version": "4.8.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/keyvault-keys/-/keyvault-keys-4.8.0.tgz",
+      "integrity": "sha1-FROzoYe7Opo3K1mAxZOWL7eTsq0=",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.5.0",
-        "@azure/core-http-compat": "^1.3.0",
+        "@azure/core-http-compat": "^2.0.1",
         "@azure/core-lro": "^2.2.0",
         "@azure/core-paging": "^1.1.1",
         "@azure/core-rest-pipeline": "^1.8.1",
@@ -274,26 +301,24 @@
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/logger": {
-      "version": "1.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/logger/-/logger-1.0.4.tgz",
-      "integrity": "sha1-KLxtDls8OO8pKWsy012k5INZP6E=",
-      "license": "MIT",
+      "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/logger/-/logger-1.1.2.tgz",
+      "integrity": "sha1-P0uHbO+tMo3BSv+LhQ1jthHiSdw=",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "2.38.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-2.38.3.tgz",
-      "integrity": "sha1-LxMfqbeoqVRvyNNOXZnOTBiwQUc=",
-      "license": "MIT",
+      "version": "2.38.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-2.38.4.tgz",
+      "integrity": "sha1-2KBPbxZLfVk3P5n6aXdXjXlrTSg=",
       "dependencies": {
         "@azure/msal-common": "13.3.1"
       },
@@ -305,7 +330,6 @@
       "version": "13.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
       "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -314,7 +338,6 @@
       "version": "7.6.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-7.6.0.tgz",
       "integrity": "sha1-tS6X71QCdfcmEc/1eTffoLNM3Mo=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -323,7 +346,6 @@
       "version": "1.18.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
       "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
-      "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "13.3.1",
         "jsonwebtoken": "^9.0.0",
@@ -337,130 +359,48 @@
       "version": "13.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
       "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha1-48HAmUAlmEg7eoxGpyHRA4gDdV4=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.24.6.tgz",
+      "integrity": "sha1-q4jaGTRERcPYiJryIWYG0zKfPvI=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.6",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/compat-data/-/compat-data-7.23.3.tgz",
-      "integrity": "sha1-P+vVUlQeYrXog6Jes+/9fHN52xE=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/compat-data/-/compat-data-7.24.6.tgz",
+      "integrity": "sha1-s2ACF2iMq7JuJfjkZwGeZtcbeuI=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/core/-/core-7.23.3.tgz",
-      "integrity": "sha1-XsCciAO5H1HMiH3twmVKNYUoSck=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/core/-/core-7.24.6.tgz",
+      "integrity": "sha1-hlDg5LA1ievohsTkpgOY2wp+x4c=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
-        "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.3",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.3",
-        "@babel/types": "^7.23.3",
+        "@babel/code-frame": "^7.24.6",
+        "@babel/generator": "^7.24.6",
+        "@babel/helper-compilation-targets": "^7.24.6",
+        "@babel/helper-module-transforms": "^7.24.6",
+        "@babel/helpers": "^7.24.6",
+        "@babel/parser": "^7.24.6",
+        "@babel/template": "^7.24.6",
+        "@babel/traverse": "^7.24.6",
+        "@babel/types": "^7.24.6",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -476,15 +416,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/generator/-/generator-7.23.3.tgz",
-      "integrity": "sha1-huboPZWQP752E/RIYTuLMZ8zCo4=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/generator/-/generator-7.24.6.tgz",
+      "integrity": "sha1-36yCoihYKp0wyVn+UK0olR1HN6c=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.23.3",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.24.6",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -492,15 +431,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha1-Bpj8RFUaJs8p8Y1GYtW/VFps/FI=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.6.tgz",
+      "integrity": "sha1-SlHWgfdoAEPTjiEnFeKnsa0py1E=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.24.6",
+        "@babel/helper-validator-option": "^7.24.6",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -509,67 +447,62 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha1-lhWdth00op26RUyVn1rkpkm6kWc=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.6.tgz",
+      "integrity": "sha1-rHrVUXghZBVQ9mmN1UaPjO94Yg0=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha1-H5o829WyaYpnDDDSc1+a+V7VJ1k=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-function-name/-/helper-function-name-7.24.6.tgz",
+      "integrity": "sha1-zr3QYzhv25XVEdhLEX5R/Gj+wMg=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "^7.24.6",
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha1-wBoAfawFwIWRTo+2UrM521DYI7s=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.6.tgz",
+      "integrity": "sha1-in7OjCZ1aCa2/83Q489l3ida9/k=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha1-FhRjB6zcQMwAw7LGR3EwdkZL2/A=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.24.6.tgz",
+      "integrity": "sha1-ZeVP/O7WomjcTOEfBDO4LP/1eFI=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.15"
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-      "integrity": "sha1-19EsPF0wr1s8D8qyptUhd3Pi0PE=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.24.6.tgz",
+      "integrity": "sha1-IjRu2d9EzoTe6FDXQzxbc/qx/k4=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
+        "@babel/helper-environment-visitor": "^7.24.6",
+        "@babel/helper-module-imports": "^7.24.6",
+        "@babel/helper-simple-access": "^7.24.6",
+        "@babel/helper-split-export-declaration": "^7.24.6",
+        "@babel/helper-validator-identifier": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -579,94 +512,86 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha1-3X7jc16KMTufewWnc9iS6I5tcpU=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.6.tgz",
+      "integrity": "sha1-+gKjJBChWm6PgYW8v2CPEFKNKiQ=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha1-STg1fcfXgrgO1tuwOg+6PSKx1d4=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-simple-access/-/helper-simple-access-7.24.6.tgz",
+      "integrity": "sha1-HW4E1Gi7pPyWO0kG9trGKGz+3/E=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha1-MixhtzEMCZf+TDI5VWZ/GPzvuRw=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.6.tgz",
+      "integrity": "sha1-6DAGj3uohhxTt0IcKE2jCuZW16M=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha1-Uz82RXolgUzx32SIUjrVR9eEqZ8=",
-      "license": "MIT",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.24.6.tgz",
+      "integrity": "sha1-KFg8KLFfKjM5z6+v6q1C+aDoKN8=",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha1-xK4ALGHSh55yRYHZZmVYPbwdwOA=",
-      "license": "MIT",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
+      "integrity": "sha1-CLtmErEb3sePP+7T2xltpoJFSl4=",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha1-aUww36HQmmU0zfyvvlZ4nTaroEA=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.24.6.tgz",
+      "integrity": "sha1-WdjoHEC32RCat+dEVzk0Qhd/Rgo=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.23.2.tgz",
-      "integrity": "sha1-KDJUmm431IQobhW6NqUzBIPKx2c=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.24.6.tgz",
+      "integrity": "sha1-zRJCRSmeSUvU4A7doOTqNUXCwXY=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "^7.24.6",
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha1-TKkrcdgFVLAUJ4FeBvLfllucH1Q=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/highlight/-/highlight-7.24.6.tgz",
+      "integrity": "sha1-bWEMHr0sbgYcreAVO/abBZC3s98=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.6",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -677,7 +602,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -690,7 +614,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -705,7 +628,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -714,15 +636,13 @@
       "version": "1.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -732,7 +652,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -742,7 +661,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -751,10 +669,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.23.3.tgz",
-      "integrity": "sha1-DOC+MaTKTxiEtXhgV8rctsO+WPk=",
-      "license": "MIT",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.24.6.tgz",
+      "integrity": "sha1-XgMPRAw8bHjRlVKMO2iLEBo2Uyg=",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -767,7 +684,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -780,7 +696,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha1-TJpvZp9dDN8bkKFnHpoUa+UwDOo=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -793,7 +708,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha1-tcmHJ0xKOoK4lxR5aTGmtTVErhA=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
       },
@@ -806,7 +720,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -819,7 +732,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -828,13 +740,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
-      "integrity": "sha1-jy5PiptfmqFgZ+FCwayc2fgQ9HM=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.6.tgz",
+      "integrity": "sha1-vMopZBUEN/iPZeNnnj1odiKHucg=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -848,7 +759,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -861,7 +771,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -874,7 +783,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -887,7 +795,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -900,7 +807,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -913,7 +819,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -926,7 +831,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha1-wc/a3DWmRiQAAfBhOCR7dBw02Uw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -938,13 +842,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
-      "integrity": "sha1-JPRgyF27yYPNK5xJlBeLzAHflY8=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.6.tgz",
+      "integrity": "sha1-dp2vKYLWAwi8g9iTbq7LdYJGPIc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -954,36 +857,34 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha1-CVdu/Dgw8EMPRUjvlx3eE1DvLzg=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.24.6.tgz",
+      "integrity": "sha1-BIw0eyeHpgcrJMcjZkyNArZ6RPk=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.24.6",
+        "@babel/parser": "^7.24.6",
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/traverse/-/traverse-7.23.3.tgz",
-      "integrity": "sha1-Ju5fJS5yWqeso0dKpbMk6veQi1s=",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/traverse/-/traverse-7.24.6.tgz",
+      "integrity": "sha1-CUHsUM3q6srQkR62euInpPhCTtw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.3",
-        "@babel/types": "^7.23.3",
-        "debug": "^4.1.0",
+        "@babel/code-frame": "^7.24.6",
+        "@babel/generator": "^7.24.6",
+        "@babel/helper-environment-visitor": "^7.24.6",
+        "@babel/helper-function-name": "^7.24.6",
+        "@babel/helper-hoist-variables": "^7.24.6",
+        "@babel/helper-split-export-declaration": "^7.24.6",
+        "@babel/parser": "^7.24.6",
+        "@babel/types": "^7.24.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -995,19 +896,17 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-11.12.0.tgz",
       "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.23.3.tgz",
-      "integrity": "sha1-1eqJLAfy7DcaxwRCD03NsHtflZg=",
-      "license": "MIT",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.24.6.tgz",
+      "integrity": "sha1-uk4fWYcMENwvqVonSsT+7COyGRI=",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.6",
+        "@babel/helper-validator-identifier": "^7.24.6",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1018,14 +917,12 @@
       "version": "0.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
       "integrity": "sha1-ojUU6Pua8SadX3eIqlVnmNYca1k=",
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -1040,16 +937,14 @@
       "version": "4.10.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
       "integrity": "sha1-VI9t5VaFfIu3O77nDDXcgqLnTWM=",
-      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
-      "integrity": "sha1-eXRwp1/g+9WlM1DucV6F6Huv8i0=",
-      "license": "MIT",
+      "version": "2.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha1-OIomnw8lwbatwxe1osVXFIlMcK0=",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -1069,22 +964,20 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.53.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-8.53.0.tgz",
-      "integrity": "sha1-vqVvLtK1uuoWQ0j/TVqHn2+B8g0=",
-      "license": "MIT",
+      "version": "8.57.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha1-pUF66EJ4c/HdCLcLNXS0U+Z7X38=",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-      "integrity": "sha1-B13JaE9ApTHZsmsIIhU8HoMu4pc=",
-      "license": "Apache-2.0",
+      "version": "0.11.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha1-145IGgOfdWbsyWYLTqf+ax/sRCs=",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -1095,7 +988,6 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha1-r1smkaIrRL6EewyoFkHF+2rQFyw=",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -1105,17 +997,15 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-      "integrity": "sha1-5SEUUt8GD6hSK1XHs8DE0ZgcsEQ=",
-      "license": "BSD-3-Clause"
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha1-Siho111taWPkI7z5C3/RvjQ0CdM="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
@@ -1132,7 +1022,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -1142,7 +1031,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -1156,7 +1044,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1170,7 +1057,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -1183,7 +1069,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -1199,7 +1084,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -1212,7 +1096,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1221,15 +1104,13 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "dev": true
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha1-5F44TkuOwWvOL9kDr3hFD2v37Jg=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1239,7 +1120,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/console/-/console-29.7.0.tgz",
       "integrity": "sha1-zUgi29uEUpJlxaK9tSmjycyVD/w=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -1257,7 +1137,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/core/-/core-29.7.0.tgz",
       "integrity": "sha1-tszMI58w/zZglljFpeIpF1fORI8=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/reporters": "^29.7.0",
@@ -1305,7 +1184,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha1-JNYfVP8feG881Ac7S5RBY4O68qc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -1321,7 +1199,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/expect/-/expect-29.7.0.tgz",
       "integrity": "sha1-dqPtsMt1O3Dfv+Iyg1ENPUVDK/I=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "expect": "^29.7.0",
         "jest-snapshot": "^29.7.0"
@@ -1335,7 +1212,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "integrity": "sha1-Aj7+XSaopw8hZ30KGvwPCkTjocY=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3"
       },
@@ -1348,7 +1224,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha1-/ZG/H/+xbX0NJKQmqxpHpJiBpWU=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
@@ -1366,7 +1241,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha1-jZKQ+exH/3cmB/qGTKHVou+uHU0=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -1382,7 +1256,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/reporters/-/reporters-29.7.0.tgz",
       "integrity": "sha1-BLJi7LO4+qg7Cz0yFiOXI5Po9Mc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "^29.7.0",
@@ -1426,7 +1299,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha1-Qwtc6KTgBEp+OBlmMwWnswkcjgM=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -1439,7 +1311,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/source-map/-/source-map-29.6.3.tgz",
       "integrity": "sha1-2Quncglc83o0peuUE/G1YqCFVMQ=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
         "callsites": "^3.0.0",
@@ -1454,7 +1325,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/test-result/-/test-result-29.7.0.tgz",
       "integrity": "sha1-jbmoCqGgl7siYlcmhnNLrtmxZXw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -1470,7 +1340,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
       "integrity": "sha1-bO+XfOHTmDSjrqiHoXJmKKbwcs4=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
         "graceful-fs": "^4.2.9",
@@ -1486,7 +1355,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha1-3y3Zw0bH13aLigZjmZRkDGQuKEw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -1513,7 +1381,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha1-ETH4z2NOfoTF53urEvBSr1hfulk=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1527,36 +1394,33 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha1-fgLm6135AartsIUUIDsJZhQCQJg=",
+      "version": "0.3.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha1-3M5q/3S99trRqVgCtpsEovyx+zY=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha1-wIZ5Bj8nlhWjMmWDujqQ0dgsxyE=",
+      "version": "3.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha1-fGz5mNbSC5FMClWpGuko/yWWXnI=",
+      "version": "1.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha1-VY+2Ry7RakyFC4iVMOazZDjEkoA=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1565,31 +1429,27 @@
       "version": "1.4.15",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha1-18bmdVx4VnqVHgSrUu8P0m3lnzI=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha1-cuRXB88kD6awgdA2b4JlsM0QGX8=",
+      "version": "0.3.25",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha1-FfGQ6YiV8/wjJ27hS8drZ1wuUPA=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@js-joda/core": {
-      "version": "5.6.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.1.tgz",
-      "integrity": "sha1-A+JFPYd7YcP1k88DH9GLN1vVSLY=",
-      "license": "BSD-3-Clause"
+      "version": "5.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.2.tgz",
+      "integrity": "sha1-GIXRDapATOor1VV1+RCrO75sM9c="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1602,7 +1462,6 @@
       "version": "2.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -1611,7 +1470,6 @@
       "version": "1.2.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -1624,15 +1482,13 @@
       "version": "0.27.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha1-Zmf6wWxDa1Q0o4ejTe2wExmPbm4=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@sinonjs/commons": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinonjs/commons/-/commons-3.0.0.tgz",
-      "integrity": "sha1-vrQ0/oddllJl4EcizPwh3391XXI=",
+      "version": "3.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha1-ECk1fkTKkBphVYX20nc428iQhM0=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -1642,26 +1498,15 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha1-Vf3/Hsq581QBkSna9N8N1Nkj6mY=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha1-9UShSNOrNYAcH2M6dEH9h8LkhL8=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@types/babel__core": {
-      "version": "7.20.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__core/-/babel__core-7.20.4.tgz",
-      "integrity": "sha1-JqhzR+bG91OzZoOY40SW1tmsasA=",
+      "version": "7.20.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha1-PfFfJ7qFMZyqB7oI0HIYibs5wBc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -1671,11 +1516,10 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__generator/-/babel__generator-7.6.7.tgz",
-      "integrity": "sha1-p66/Fce8Drmr1ji9tcC4cAOZydA=",
+      "version": "7.6.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha1-+DbGH0ixNG59Kw2TxtrMW5U106s=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -1685,18 +1529,16 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha1-VnJRNwHBshmbxtrWNqnXSRWGdm8=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
-      "integrity": "sha1-7CwG/tZUnfi8DrRhW2g3SaSpLhs=",
+      "version": "7.20.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
+      "integrity": "sha1-jcnwrg8gLAjY1Nq2SJEsjWA44/c=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
@@ -1705,16 +1547,14 @@
       "version": "4.1.12",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha1-oVXyFpCHGVNBDfS2tvUxh/BQCRc=",
-      "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
     },
     "node_modules/@types/es-aggregate-error": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/es-aggregate-error/-/es-aggregate-error-1.0.5.tgz",
-      "integrity": "sha1-DV97SkVZcz6nc/w7TQj+tEUOVgg=",
-      "license": "MIT",
+      "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/es-aggregate-error/-/es-aggregate-error-1.0.6.tgz",
+      "integrity": "sha1-FHLfsPsctMPyvTsqe34Z9godZsA=",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1724,7 +1564,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha1-Kga8D2iiCrN7PjaqI4vmq99J6LQ=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1733,15 +1572,13 @@
       "version": "2.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha1-dznCMqH+6bTTzomF8xTAxtM1Sdc=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha1-UwR2FK5y4Z/AQB2HLeOuK0zjUL8=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -1751,7 +1588,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha1-DwPj0vZw+9rFhuNLQzeDBwzBb1Q=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -1760,20 +1596,17 @@
       "version": "0.0.29",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha1-EJZLoN7mrEzUYuJ5W2vr1AcwNDM=",
-      "license": "MIT"
+      "integrity": "sha1-EJZLoN7mrEzUYuJ5W2vr1AcwNDM="
     },
     "node_modules/@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha1-v83CMFg664kc9R5zz9qs3Y3q4pg=",
-      "license": "MIT",
+      "version": "20.12.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha1-fL7N+QIIXOxjT9s2IXLf4SuPIFA=",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1782,21 +1615,18 @@
       "version": "2.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha1-YgkyHrLBcSp+dGZCK4yx/A2d1dg=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/validator": {
-      "version": "13.11.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/validator/-/validator-13.11.6.tgz",
-      "integrity": "sha1-hkXv7f2JG8HXrYJTkAXX/3hf4pQ=",
-      "license": "MIT"
+      "version": "13.11.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/validator/-/validator-13.11.10.tgz",
+      "integrity": "sha1-/rNkAYzdHz2XCp6MfxwxTAomT/8="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.31",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs/-/yargs-17.0.31.tgz",
-      "integrity": "sha1-j9AImAP9VdiihYlaGLiMtxqZaDw=",
+      "version": "17.0.32",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha1-Awd0cjovf6r+v2RfTlpINx3KYik=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1805,20 +1635,17 @@
       "version": "21.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha1-gV4wt4bS6PDc2F/VvPXhoE0AjxU=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha1-dWZBrbWHhRtcyz4JXa8nrlgchAY=",
-      "license": "ISC"
+      "integrity": "sha1-dWZBrbWHhRtcyz4JXa8nrlgchAY="
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.10",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
       "integrity": "sha1-oTN8pCaqYc75/hW1so40CnL2+pk=",
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1826,14 +1653,12 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
-      "license": "ISC"
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha1-C/C+EltnAUrcsLCSHmLbe//hay4=",
-      "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -1843,10 +1668,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha1-yg14tRiVvlOQpZA8Wzvc2veK5As=",
-      "license": "MIT",
+      "version": "8.11.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha1-ceCxThOk7BYHJLOPt7DyM7G4HXo=",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1858,7 +1682,6 @@
       "version": "5.3.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -1867,7 +1690,6 @@
       "version": "0.2.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/adal-node/-/adal-node-0.2.4.tgz",
       "integrity": "sha1-iBvu2dSTt2qGcGrVyNxvYO/wRSA=",
-      "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.3",
         "async": "^2.6.3",
@@ -1886,7 +1708,6 @@
       "version": "2.6.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async/-/async-2.6.4.tgz",
       "integrity": "sha1-cGt/9ghGZM1+rnE/b5ZUM7VQQiE=",
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -1895,28 +1716,25 @@
       "version": "3.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
-      "license": "MIT",
+      "version": "7.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha1-vb3tffsJa3UaKgh+7rlmRyWy4xc=",
       "dependencies": {
-        "debug": "4"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1932,7 +1750,6 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "license": "BSD-3-Clause OR MIT",
       "engines": {
         "node": ">=0.4.2"
       }
@@ -1942,7 +1759,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -1958,7 +1774,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -1970,7 +1785,6 @@
       "version": "5.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1979,7 +1793,6 @@
       "version": "4.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1995,7 +1808,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha1-eQxYsZuhcgqEIFtXxhjVrYUklz4=",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2008,7 +1820,6 @@
       "version": "0.0.10",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/apparatus/-/apparatus-0.0.10.tgz",
       "integrity": "sha1-gep1Z3Ktp3hj21TO7oICwQm9yj4=",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "sylvester": ">= 0.0.8"
@@ -2020,17 +1831,18 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
-      "license": "Python-2.0"
+      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-      "integrity": "sha1-+r6LwZP+qGXzF/54Bwhe4N7lrq0=",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha1-HlWD7BZ2NUCieuUu7Zn/iZIjVo8=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-array-buffer": "^3.0.1"
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2039,20 +1851,19 @@
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-      "license": "MIT"
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "node_modules/array-includes": {
-      "version": "3.1.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-includes/-/array-includes-3.1.7.tgz",
-      "integrity": "sha1-jNLgGyb3owhsvIcnFZP+khxiq9o=",
+      "version": "3.1.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-includes/-/array-includes-3.1.8.tgz",
+      "integrity": "sha1-XjcMvhcv3V3WUwwdSq3aJSgbqX0=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -2063,17 +1874,17 @@
       }
     },
     "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.3.tgz",
-      "integrity": "sha1-s3WYQ4+XtXkWaUCBTiwEk6T1Agc=",
+      "version": "1.2.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+      "integrity": "sha1-jDWnVccpCHGUU/hxRcoBHjkzTQ0=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2087,7 +1898,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
       "integrity": "sha1-FHYhffjP8X1y7o87oGc421s4fRg=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -2106,7 +1916,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
       "integrity": "sha1-yafGgx245xnWzmORkBRsJLvT5Sc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -2121,17 +1930,17 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
-      "integrity": "sha1-mL1WGVPj50uzSTjndkcXnf5unxI=",
-      "license": "MIT",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha1-CXly9CVeQbw0JeN9w/ZCHPmu/eY=",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "is-array-buffer": "^3.0.2",
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
         "is-shared-array-buffer": "^1.0.2"
       },
       "engines": {
@@ -2144,17 +1953,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "license": "MIT"
-    },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha1-DTp7tuZOAqkMAwOzHykoaOoJoI0=",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "node_modules/assert-never": {
       "version": "1.2.1",
@@ -2165,7 +1964,6 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -2173,20 +1971,17 @@
     "node_modules/async": {
       "version": "3.2.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async/-/async-3.2.5.tgz",
-      "integrity": "sha1-69Uqj9r3oiiaJN85n42Ehcika2Y=",
-      "license": "MIT"
+      "integrity": "sha1-69Uqj9r3oiiaJN85n42Ehcika2Y="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "license": "MIT"
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
-      "license": "(MIT OR Apache-2.0)",
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -2195,10 +1990,12 @@
       }
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha1-kvlWFlAQadB9EO2y/DfT4cZRI7c=",
-      "license": "MIT",
+      "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha1-pcw3XWoDwu/IelU/PgsVIt7xSEY=",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2207,10 +2004,10 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1493.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/aws-sdk/-/aws-sdk-2.1493.0.tgz",
-      "integrity": "sha1-IN/aSO6/K5XOpd9ldupEe7qBV28=",
-      "license": "Apache-2.0",
+      "version": "2.1628.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/aws-sdk/-/aws-sdk-2.1628.0.tgz",
+      "integrity": "sha1-fSk4fg0VncjpaYla27lWZPmwfOE=",
+      "hasInstallScript": true,
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -2221,7 +2018,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.5.0"
+        "xml2js": "0.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -2231,31 +2028,14 @@
       "version": "8.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-8.0.0.tgz",
       "integrity": "sha1-vGzPkbX/CsB7vNvxx8ThUNtNu2w=",
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.12.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/aws4/-/aws4-1.12.0.tgz",
-      "integrity": "sha1-zhydFDOJZ54lOzFCQeqapc7JgNM=",
-      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "0.21.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-0.21.4.tgz",
       "integrity": "sha1-xnuQ3AVo5cHPKwuFjEO6KOLtpXU=",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -2265,7 +2045,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha1-9DaZGSJbaExWCFmYrGPb0FvgINU=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -2287,7 +2066,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
       "integrity": "sha1-+ojsWSMv2bTjbbvFQKjsmptH2nM=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -2304,7 +2082,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "integrity": "sha1-0QyIhcISVXThwjHKyt+VVnXhzj0=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
         "@babel/parser": "^7.14.7",
@@ -2321,7 +2098,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha1-qtvpQ0ZBgqiSLDySfDBn/0DSRiY=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
@@ -2337,7 +2113,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
       "integrity": "sha1-tDmSObibKgEfndvj5PQB/EDP9zs=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -2361,7 +2136,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha1-+gX6UQ59STiW17DdIDNgHIQPFxw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0"
@@ -2387,8 +2161,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
-      "license": "MIT"
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2407,23 +2180,12 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
+      ]
     },
     "node_modules/bl": {
       "version": "5.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-5.1.0.tgz",
       "integrity": "sha1-GDcV9njHGI7O+f5HXZAglABiQnM=",
-      "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -2448,7 +2210,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -2471,14 +2232,12 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
-      "license": "MIT"
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -2507,7 +2266,6 @@
       "version": "2.6.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -2515,36 +2273,33 @@
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "license": "MIT"
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.22.1.tgz",
-      "integrity": "sha1-upGVjRpZuH2rb+2N+8s9peLpxhk=",
+      "version": "4.23.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha1-jzrMK75zr3ITOZQwiQ+GxjpWdKs=",
       "dev": true,
       "funding": [
         {
@@ -2560,11 +2315,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001541",
-        "electron-to-chromium": "^1.4.535",
-        "node-releases": "^2.0.13",
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
         "update-browserslist-db": "^1.0.13"
       },
       "bin": {
@@ -2579,7 +2333,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bser/-/bser-2.1.1.tgz",
       "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
       }
@@ -2588,7 +2341,6 @@
       "version": "4.9.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -2598,15 +2350,13 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "license": "BSD-3-Clause"
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2617,14 +2367,18 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha1-b6K3hFzg6km/TYue9kcnosLi5RM=",
-      "license": "MIT",
+      "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha1-BgFlmcQMVkmMGHadJzC+JCtvo7k=",
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2634,7 +2388,6 @@
       "version": "3.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2644,15 +2397,14 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001561",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
-      "integrity": "sha1-dS8h9W+W8bGlLpeq6YxXxWLV2do=",
+      "version": "1.0.30001624",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001624.tgz",
+      "integrity": "sha1-DsTI+npG5beFR3xws4pW0LEAWOs=",
       "dev": true,
       "funding": [
         {
@@ -2667,20 +2419,12 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "license": "Apache-2.0"
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2697,7 +2441,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -2706,7 +2449,6 @@
       "version": "2.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/character-parser/-/character-parser-2.2.0.tgz",
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
-      "license": "MIT",
       "dependencies": {
         "is-regex": "^1.0.3"
       }
@@ -2722,23 +2464,20 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha1-bDcKsZ+KM5TjGP5oJobsCsaE0Qc=",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+      "integrity": "sha1-xIU0Guj9mZyk7lry16HJrgHgCZw=",
+      "dev": true
     },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
-      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2752,7 +2491,6 @@
       "version": "2.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -2762,7 +2500,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -2772,14 +2509,12 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
       "integrity": "sha1-wLKbzTO80HeaE0TCE2BR5q/T2ek=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2790,14 +2525,12 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "license": "MIT"
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2808,21 +2541,18 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "license": "MIT"
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha1-rkDptXzdORVAiigF69OlWFYI3IE=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/constantinople": {
       "version": "4.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/constantinople/-/constantinople-4.0.1.tgz",
       "integrity": "sha1-De8RP6Dk3I3oMzGlz3nIsyUhMVE=",
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.6.0",
         "@babel/types": "^7.6.1"
@@ -2832,7 +2562,6 @@
       "version": "0.5.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha1-i4K076yCUSoCuwsdzsnSxejrW/4=",
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -2844,7 +2573,6 @@
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha1-i3cxYmVtHRCGeEyPI6VM5tc9eRg=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2853,8 +2581,7 @@
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -2867,21 +2594,18 @@
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "license": "MIT"
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "license": "MIT"
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/create-jest/-/create-jest-29.7.0.tgz",
       "integrity": "sha1-o1XFs8seGvAroXf+ev1/7uSaUyA=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
@@ -2902,7 +2626,6 @@
       "version": "7.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2916,7 +2639,6 @@
       "version": "2.2.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/css/-/css-2.2.4.tgz",
       "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "source-map": "^0.6.1",
@@ -2928,28 +2650,62 @@
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/css-parse/-/css-parse-2.0.0.tgz",
       "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-      "license": "MIT",
       "dependencies": {
         "css": "^2.0.0"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "license": "MIT",
+    "node_modules/data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha1-jqYybv7Bei5CYgaW5nHX1ai8ZrI=",
       "dependencies": {
-        "assert-plus": "^1.0.0"
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
       },
       "engines": {
-        "node": ">=0.10"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha1-kHIcqV/ygGd+t5N0n84QETR2aeI=",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha1-Xgu/tIKO0tG5tADNin0Rm8oP8Yo=",
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/date-utils": {
       "version": "1.2.21",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/date-utils/-/date-utils-1.2.21.tgz",
       "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=",
-      "license": "MIT",
       "engines": {
         "node": ">0.4.0"
       }
@@ -2958,7 +2714,6 @@
       "version": "4.3.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.4.tgz",
       "integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2975,17 +2730,15 @@
       "version": "0.2.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
       "integrity": "sha1-5p2+JdN5QRcd1UDgJMREzVGI4ek=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/dedent": {
-      "version": "1.5.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dedent/-/dedent-1.5.1.tgz",
-      "integrity": "sha1-Tz/JTItxHpuygA0YXNatIPKpCv8=",
+      "version": "1.5.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dedent/-/dedent-1.5.3.tgz",
+      "integrity": "sha1-ma7hnrm65VpnMncXtuhI0L93flo=",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -2998,38 +2751,37 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
-      "license": "MIT"
+      "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE="
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha1-RLXyFHzTsA1LVhN2hZZvJv0l3Uo=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha1-w1980KsJiDSA0SrFyyE3FVh4ALM=",
-      "license": "MIT",
+      "version": "1.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4=",
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3038,7 +2790,6 @@
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha1-EHgcxhbrlRqAoDS6/Kpzd/avK2w=",
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -3055,7 +2806,6 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3064,7 +2814,6 @@
       "version": "1.5.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/denque/-/denque-1.5.1.tgz",
       "integrity": "sha1-B/Zw4pyaePj67LJWah4sEZKcXL8=",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
       }
@@ -3073,7 +2822,6 @@
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/depd/-/depd-2.0.0.tgz",
       "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3082,7 +2830,6 @@
       "version": "1.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha1-SANzVQmti+VSk0xn32FPlOZvoBU=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -3093,7 +2840,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3103,7 +2849,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha1-Ter4lNEUB8Ue/IQYAS+ecLhOqSE=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3112,7 +2857,6 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
-      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -3128,31 +2872,18 @@
     "node_modules/dottie": {
       "version": "2.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dottie/-/dottie-2.0.6.tgz",
-      "integrity": "sha1-NFZOv8bsXldyJy1GZCStW2lkhNQ=",
-      "license": "MIT"
+      "integrity": "sha1-NFZOv8bsXldyJy1GZCStW2lkhNQ="
     },
     "node_modules/double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
-      "license": "MIT",
       "optional": true
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
-      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -3160,8 +2891,7 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "license": "MIT"
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -3178,18 +2908,16 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.580",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.580.tgz",
-      "integrity": "sha1-L49w9wczpr4ftvMd4SJObcS7GW0=",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.4.783",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.783.tgz",
+      "integrity": "sha1-kziHFluLYCWoFmPS2Xz0uFzeJ7I=",
+      "dev": true
     },
     "node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha1-wEuMNFdJDghHrlH87Tr1LTOOPa0=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -3200,14 +2928,12 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "license": "MIT"
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3217,56 +2943,61 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.22.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-abstract/-/es-abstract-1.22.3.tgz",
-      "integrity": "sha1-SOefVXMZjebe41iRlXJ/T3S8TzI=",
-      "license": "MIT",
+      "version": "1.23.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-abstract/-/es-abstract-1.23.3.tgz",
+      "integrity": "sha1-jwxaNc0hUxJXPFonyH39bIgaCqA=",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.2",
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.5",
-        "es-set-tostringtag": "^2.0.1",
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
         "es-to-primitive": "^1.2.1",
         "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.2",
-        "get-symbol-description": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "has-proto": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
         "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0",
-        "internal-slot": "^1.0.5",
-        "is-array-buffer": "^3.0.2",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
         "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
+        "is-shared-array-buffer": "^1.0.3",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.12",
+        "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.13.1",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "safe-array-concat": "^1.0.1",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.8",
-        "string.prototype.trimend": "^1.0.7",
-        "string.prototype.trimstart": "^1.0.7",
-        "typed-array-buffer": "^1.0.0",
-        "typed-array-byte-length": "^1.0.0",
-        "typed-array-byte-offset": "^1.0.0",
-        "typed-array-length": "^1.0.4",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.6",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.13"
+        "which-typed-array": "^1.1.15"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3276,19 +3007,18 @@
       }
     },
     "node_modules/es-aggregate-error": {
-      "version": "1.0.11",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-aggregate-error/-/es-aggregate-error-1.0.11.tgz",
-      "integrity": "sha1-AT1rIFoYdQROjduFkqqL1bbLIcU=",
-      "license": "MIT",
+      "version": "1.0.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-aggregate-error/-/es-aggregate-error-1.0.13.tgz",
+      "integrity": "sha1-fyi3fJ2NCbvNOkZuS+n+AvqYUgE=",
       "dependencies": {
-        "define-data-property": "^1.1.0",
+        "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
         "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "set-function-name": "^2.0.1"
+        "has-property-descriptors": "^1.0.2",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3297,15 +3027,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
-      "integrity": "sha1-EffMn2M3aTCl8gvkkVg09Lx0+ck=",
-      "license": "MIT",
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha1-x/rvvf+LJpbPX0aSHt+3fMS6OEU=",
       "dependencies": {
-        "get-intrinsic": "^1.2.2",
-        "has-tostringtag": "^1.0.0",
-        "hasown": "^2.0.0"
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha1-3bVc1HrC4kBwEmC8Ko4x7LZD2UE=",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha1-i7YPCkQMLkKBliQoQ41YVFrzl3c=",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3316,7 +3075,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
       "integrity": "sha1-H2lC5x7MeDXtHIqDAG2HcaY6N2M=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.0"
       }
@@ -3325,7 +3083,6 @@
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
-      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3339,10 +3096,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
-      "license": "MIT",
+      "version": "3.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha1-VAdumrKepb89jx7WKs/7uIJy3yc=",
       "engines": {
         "node": ">=6"
       }
@@ -3350,14 +3106,12 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "license": "MIT"
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3366,16 +3120,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.53.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-8.53.0.tgz",
-      "integrity": "sha1-FPLIJEKY/K4fRpRUWVd0E7oml84=",
-      "license": "MIT",
+      "version": "8.57.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha1-x4am/Q4LaJQar2JFlvuYcIkZVmg=",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.3",
-        "@eslint/js": "8.53.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -3425,7 +3178,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
       "integrity": "sha1-awmt2QrHnC+NcjolgOB/OSWv0jY=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
@@ -3445,7 +3197,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
       "integrity": "sha1-1OqsUrii58PNGQPrAPfgUzVhGKw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
         "is-core-module": "^2.13.0",
@@ -3457,17 +3208,15 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.2.7.tgz",
       "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.8.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
-      "integrity": "sha1-5Dn+5l/DP2u6Yw/2Ie/DjsA3XEk=",
+      "version": "2.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
+      "integrity": "sha1-UvJAQwDDvTPe7OnXNy+zN8wdfDQ=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7"
       },
@@ -3485,17 +3234,15 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.2.7.tgz",
       "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.29.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-      "integrity": "sha1-gTMjLkMp7jRPL2Eohawwc7C34VU=",
+      "version": "2.29.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha1-1Fs3te9ZAdY5wVJw101G0WEVBkM=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -3513,7 +3260,7 @@
         "object.groupby": "^1.0.1",
         "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
@@ -3527,7 +3274,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.2.7.tgz",
       "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -3537,7 +3283,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -3549,7 +3294,6 @@
       "version": "7.2.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha1-3rT5JWM5DzIAaJSvYqItuhxGQj8=",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -3565,7 +3309,6 @@
       "version": "3.4.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -3577,7 +3320,6 @@
       "version": "9.6.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/espree/-/espree-9.6.1.tgz",
       "integrity": "sha1-oqF7jkNGkKVDLy+AGM5x0zGkjG8=",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -3595,7 +3337,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true,
-      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -3608,7 +3349,6 @@
       "version": "1.5.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esquery/-/esquery-1.5.0.tgz",
       "integrity": "sha1-bOF3ON6Fd2lO3XNhxXGCrIyw2ws=",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -3620,7 +3360,6 @@
       "version": "4.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -3632,7 +3371,6 @@
       "version": "5.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -3641,7 +3379,6 @@
       "version": "2.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3650,7 +3387,6 @@
       "version": "1.8.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3659,7 +3395,6 @@
       "version": "1.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
       }
@@ -3669,7 +3404,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/execa/-/execa-5.1.1.tgz",
       "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -3702,7 +3436,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/expect/-/expect-29.7.0.tgz",
       "integrity": "sha1-V4h0WQ3LMhRRQITAgRXYruYeEbw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
         "jest-get-type": "^29.6.3",
@@ -3759,7 +3492,6 @@
       "version": "2.6.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3767,47 +3499,35 @@
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "license": "MIT"
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
-      "license": "MIT"
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "version": "1.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha1-jRcsBkhn8jXAyEpZaAbSeb9LzAc=",
       "engines": [
         "node >=0.6.0"
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
-      "license": "MIT"
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
-      "license": "MIT"
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "license": "MIT"
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha1-0E0HxqKmj+RZn+qNLhA6k3+uazo=",
-      "license": "ISC",
+      "version": "1.17.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha1-KlI/B6TnsegaQrkbi/IlQQd1O0c=",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -3817,7 +3537,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fb-watchman/-/fb-watchman-2.0.2.tgz",
       "integrity": "sha1-6VJO5rXHfp5QAa8PhfOtu4YjJVw=",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
       }
@@ -3826,7 +3545,6 @@
       "version": "6.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
-      "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -3838,7 +3556,6 @@
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/filelist/-/filelist-1.0.4.tgz",
       "integrity": "sha1-94l4oelEd1/55i50RCTyFeWDUrU=",
-      "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
       }
@@ -3847,7 +3564,6 @@
       "version": "2.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3856,7 +3572,6 @@
       "version": "5.1.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha1-HPy4z1Ui6mmVLNKvla4JR38SKpY=",
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3865,11 +3580,10 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+      "version": "7.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3881,7 +3595,6 @@
       "version": "1.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/finalhandler/-/finalhandler-1.2.0.tgz",
       "integrity": "sha1-fSP+VzGyB7RkDk/NAK7B+SB6ezI=",
-      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -3899,7 +3612,6 @@
       "version": "2.6.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3907,14 +3619,12 @@
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "license": "MIT"
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -3927,24 +3637,22 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flat-cache/-/flat-cache-3.1.1.tgz",
-      "integrity": "sha1-oCoV/ewlqPhE/3zGWPA92Z60YJs=",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha1-LAwtUEDJmxYydxqdEFclwBFTY+4=",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha1-frTGfKG6NCMsqdLZPpiG5hGtfa8=",
-      "license": "ISC"
+      "version": "3.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha1-IdtHBymmc01JlwAvQ5yzCJh/Vno="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -3969,39 +3677,27 @@
       "version": "0.3.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
-      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
-      "license": "MIT",
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha1-ImmTZCiq1MFcfr6XeahL8LKoGBE=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4010,7 +3706,6 @@
       "version": "0.5.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4018,15 +3713,13 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "license": "ISC"
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4039,7 +3732,6 @@
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4048,7 +3740,6 @@
       "version": "1.1.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha1-zfMVt9kO53pMbuIWw8M2LaB1M/0=",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -4066,7 +3757,6 @@
       "version": "1.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4076,7 +3766,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4085,21 +3774,23 @@
       "version": "2.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
-      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha1-KBt2IpcRI+HvSzyQ/XU5MG2pPzs=",
-      "license": "MIT",
+      "version": "1.2.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha1-44X1pLUifUScPqu60FSU7wq76t0=",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4110,7 +3801,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4120,7 +3810,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4129,13 +3818,13 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha1-f9uByQAQH71WTdXxowr1qtweWNY=",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha1-UzdE1aogrKTgecjl2vf9RCAoIfU=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4144,20 +3833,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-7.2.3.tgz",
       "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4177,7 +3856,6 @@
       "version": "6.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -4186,10 +3864,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha1-7zFnPJJqCXbh9h2rTcpX4MCorwI=",
-      "license": "MIT",
+      "version": "13.24.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha1-hDKhnXjODB6DOUnDats0VAC7EXE=",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -4201,12 +3878,12 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha1-WFKIKlK4DcMBsGYCc+HtCC8LbM8=",
-      "license": "MIT",
+      "version": "1.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha1-dDDtOpddl7+1m8zkH1yruvplEjY=",
       "dependencies": {
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4219,7 +3896,6 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha1-Kf923mnax0ibfAkYpXiOVkd8Myw=",
-      "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -4231,42 +3907,17 @@
       "version": "4.2.11",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha1-+y8dVeDjoYSa7/yQxPoN1ToOZsY=",
-      "license": "MIT"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
+      "integrity": "sha1-+y8dVeDjoYSa7/yQxPoN1ToOZsY="
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo=",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4275,28 +3926,25 @@
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha1-UrowtsXsh/2J+ldLwcORJcb2U0A=",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ=",
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha1-GIXBMFU4lYr/Rp/vN5N8InlUCOA=",
-      "license": "MIT",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha1-sx3f6bDm6ZFFNqarKGQm0CFPd/0=",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4308,7 +3956,6 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4317,12 +3964,11 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4332,10 +3978,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha1-9MUT1FSle3x+FlB3jeImsRcAVGw=",
-      "license": "MIT",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4347,14 +3992,12 @@
       "version": "2.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha1-t3dKFIbvc892Z6ya4IWMASxXudM=",
-      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -4367,45 +4010,27 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha1-USmAAgNSDUNPFCvHj/PBcIAPK0M=",
-      "license": "MIT",
+      "version": "7.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
-      "license": "MIT",
+      "version": "7.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha1-jpe4QaAprY3chzHyZZW62GjLQWg=",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -4413,7 +4038,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
       }
@@ -4432,14 +4056,12 @@
     "node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
-      "license": "BSD-3-Clause"
+      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q="
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha1-opHAxheP8blgvv5H/N7DAWdKYyQ=",
-      "license": "MIT",
+      "version": "5.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha1-UHPlVM1CxbM7OUN19Ti4WT401O8=",
       "engines": {
         "node": ">= 4"
       }
@@ -4448,7 +4070,6 @@
       "version": "3.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
-      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -4465,7 +4086,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-local/-/import-local-3.1.0.tgz",
       "integrity": "sha1-tEed+KX9RPbNziQHBnVnYGPJXLQ=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -4484,7 +4104,6 @@
       "version": "0.1.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
@@ -4495,14 +4114,12 @@
       "integrity": "sha1-ZappbE4tpiJbFI16FUxEk2ZjOjI=",
       "engines": [
         "node >= 0.4.0"
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4511,16 +4128,14 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "license": "ISC"
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "node_modules/internal-slot": {
-      "version": "1.0.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/internal-slot/-/internal-slot-1.0.6.tgz",
-      "integrity": "sha1-N+dWCYxJEcXpErjtv3HtOqEW+TA=",
-      "license": "MIT",
+      "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha1-wG3Mo+2HQkmIEAewpVI7FyoZCAI=",
       "dependencies": {
-        "get-intrinsic": "^1.2.2",
+        "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       },
@@ -4532,7 +4147,6 @@
       "version": "1.9.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -4541,7 +4155,6 @@
       "version": "1.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha1-FbP4j9oB8ql/7ITKdhpWDxI++ps=",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -4554,14 +4167,15 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-      "integrity": "sha1-8mU87YQSCBY47LDrvQxBxuCuy74=",
-      "license": "MIT",
+      "version": "3.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha1-eh+Ss9Ye3SvGXSTxMFMOqT1/rpg=",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
-        "is-typed-array": "^1.1.10"
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4571,14 +4185,12 @@
       "version": "0.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
-      "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -4590,7 +4202,6 @@
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -4606,7 +4217,6 @@
       "version": "1.2.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha1-O8KoXqdC2eNiBdys3XLKH9xRsFU=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4618,9 +4228,22 @@
       "version": "2.13.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha1-rQ11Msb+qdoevcgnQtdFJcYnM4Q=",
-      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-data-view/-/is-data-view-1.0.1.tgz",
+      "integrity": "sha1-S006URtw89wm1CwDypylFdhHdZ8=",
+      "dependencies": {
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4630,7 +4253,6 @@
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
-      "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -4645,7 +4267,6 @@
       "version": "2.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
-      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -4660,7 +4281,6 @@
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-expression/-/is-expression-4.0.0.tgz",
       "integrity": "sha1-wzFVliq/IdCv0lUlFNZ9LsFv0qs=",
-      "license": "MIT",
       "dependencies": {
         "acorn": "^7.1.1",
         "object-assign": "^4.1.1"
@@ -4670,7 +4290,6 @@
       "version": "7.4.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4682,7 +4301,6 @@
       "version": "2.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4691,7 +4309,6 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4701,7 +4318,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4710,7 +4326,6 @@
       "version": "1.0.10",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha1-8VWLrxrBfg3up8BBXEODUf8rPHI=",
-      "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -4725,7 +4340,6 @@
       "version": "4.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -4734,10 +4348,9 @@
       }
     },
     "node_modules/is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha1-e/bwOigAO4s5Zd46wm9mTXZfMVA=",
-      "license": "MIT",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha1-ztkDoCespjgbd3pXQwadc3akl0c=",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4750,7 +4363,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4759,7 +4371,6 @@
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
-      "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -4774,7 +4385,6 @@
       "version": "3.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4782,14 +4392,12 @@
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha1-OauVnMv5p3TPB597QMeib3YxNfE=",
-      "license": "MIT"
+      "integrity": "sha1-OauVnMv5p3TPB597QMeib3YxNfE="
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -4802,12 +4410,14 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha1-jyWcVztgtqMtQFihoHQwwKc0THk=",
-      "license": "MIT",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha1-Ejfxy6BZzbYkMdN43MN9loAYFog=",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4818,7 +4428,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -4830,7 +4439,6 @@
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
-      "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -4845,7 +4453,6 @@
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
-      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -4857,12 +4464,11 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha1-0Lq1aG70p296cwl7lUcKsZnFfUo=",
-      "license": "MIT",
+      "version": "1.1.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha1-1sXKVt9iM0lZMi19fdHMpQ3r4ik=",
       "dependencies": {
-        "which-typed-array": "^1.1.11"
+        "which-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4871,17 +4477,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "license": "MIT"
-    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -4893,7 +4492,6 @@
       "version": "2.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
-      "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -4904,41 +4502,31 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "license": "MIT"
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "license": "MIT"
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha1-LRZsSwZE1Do58Ev2wu3R5YXzF1Y=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
-      "integrity": "sha1-ceh3B+gEFChzJRjG+1IRdhdT+98=",
+      "version": "6.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+      "integrity": "sha1-kWVZNs9zgOTkczgwgeOEeLaZk7E=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^7.5.4"
       },
@@ -4946,28 +4534,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha1-SDmG7E7TjhxsSMNIlKkYLb/2im4=",
+      "version": "7.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4975,19 +4546,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha1-kIMFusmlvRdaxqdEier9D8JEWn0=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -5002,7 +4565,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
       "integrity": "sha1-iV86cJ/PujTG3lpCk5Ai8+Q1hVE=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
@@ -5013,11 +4575,10 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-      "integrity": "sha1-JUS8q0doFUKBovCHBHGQJwTMqho=",
+      "version": "3.1.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha1-2u0SueHcpRjhXAVuHlN+dBKA+gs=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -5027,10 +4588,9 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.8.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jake/-/jake-10.8.7.tgz",
-      "integrity": "sha1-Y6MoIRd5QMM/NW4LpE/5004cfY8=",
-      "license": "Apache-2.0",
+      "version": "10.9.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jake/-/jake-10.9.1.tgz",
+      "integrity": "sha1-jclrf8xByxmqUCr1BtpOHVb15is=",
       "dependencies": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
@@ -5049,7 +4609,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest/-/jest-29.7.0.tgz",
       "integrity": "sha1-mUZ2/CQXfwiPHF43N/VpcgT/JhM=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5076,7 +4635,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
       "integrity": "sha1-HAbQfnfHjhWF0CBCTe3BDW4XrDo=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
         "jest-util": "^29.7.0",
@@ -5091,7 +4649,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-circus/-/jest-circus-29.7.0.tgz",
       "integrity": "sha1-toF6RfzINdixbVli0MAmRz7jZoo=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -5123,7 +4680,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-cli/-/jest-cli-29.7.0.tgz",
       "integrity": "sha1-VZLJQHmODK5nfuwWkmTy2DmjeZU=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/test-result": "^29.7.0",
@@ -5157,7 +4713,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-config/-/jest-config-29.7.0.tgz",
       "integrity": "sha1-vL2ogG28wBseMWpGu3QIWoSwJF8=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/test-sequencer": "^29.7.0",
@@ -5203,7 +4758,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha1-AXk0pm67fs9vIF6EaZvhCv1wRYo=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -5219,7 +4773,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "integrity": "sha1-j922rcPNyVXJPiqH9hz9NQ1dEZo=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -5232,7 +4785,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-each/-/jest-each-29.7.0.tgz",
       "integrity": "sha1-FiqbPyMovdmRvqq/+7dHReVld9E=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
@@ -5249,7 +4801,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha1-C5PhEd2o7BILyDAObR+5V24WQ3Y=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -5267,7 +4818,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha1-NvSZ/c6hl8EEWhJzGcBIFyOQj9E=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -5277,7 +4827,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha1-PCOWUkSC9aBQY3bmyFjDu8wXsQQ=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -5303,7 +4852,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
       "integrity": "sha1-W37A2t/f7Ayjg9yaoBbTa16kxyg=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3",
         "pretty-format": "^29.7.0"
@@ -5317,7 +4865,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha1-ro/sef8kn9WSzoDj7kdOg6bETxI=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^29.7.0",
@@ -5333,7 +4880,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha1-i8OS4gTpXf51ZKu+cqQE4o5R9/M=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -5354,7 +4900,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha1-ToNs9g6Zxvz6vp+Z0Bfz/dUKY0c=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -5369,7 +4914,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha1-kwsVRhZNStWTfVVA5xHU041MrS4=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -5387,7 +4931,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha1-SlVtnHdq9o4cX0gZT00DJ9JOilI=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -5397,7 +4940,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "integrity": "sha1-ZNaomS3Sb2NasMAeXu9Dmca8vDA=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
@@ -5418,7 +4960,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
       "integrity": "sha1-GwTywJXzf8d2/0CAPckpIbHohCg=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.6.3",
         "jest-snapshot": "^29.7.0"
@@ -5432,7 +4973,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-runner/-/jest-runner-29.7.0.tgz",
       "integrity": "sha1-gJrwctQIpT3P0uhJpMl20xMvcY4=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/environment": "^29.7.0",
@@ -5465,7 +5005,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-runtime/-/jest-runtime-29.7.0.tgz",
       "integrity": "sha1-7+yzFBz303Z6OgzI98mZBYfT2Bc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -5499,7 +5038,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "integrity": "sha1-wsV0w/UYZdobsykDZ3imm/iKa+U=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
@@ -5526,28 +5064,11 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha1-SDmG7E7TjhxsSMNIlKkYLb/2im4=",
+      "version": "7.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5555,19 +5076,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/jest-snapshot/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha1-I8K2K/sivoK0TemAVYAv83EPwLw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -5585,7 +5098,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-validate/-/jest-validate-29.7.0.tgz",
       "integrity": "sha1-e/cFURxk2lkdRrFfzkFADVIUfZw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
@@ -5603,7 +5115,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -5616,7 +5127,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-watcher/-/jest-watcher-29.7.0.tgz",
       "integrity": "sha1-eBDTDWGcOmIJMiPOa7NZyhsoovI=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5636,7 +5146,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha1-rK0HOsu663JivVOJ4bz0PhAFjUo=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "jest-util": "^29.7.0",
@@ -5652,7 +5161,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5667,7 +5175,6 @@
       "version": "0.16.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha1-sVsKhd/U2TDUPmntYFlDyAJ4UHY=",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -5675,8 +5182,7 @@
     "node_modules/js-md4": {
       "version": "0.3.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
-      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
-      "license": "MIT"
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU="
     },
     "node_modules/js-stringify": {
       "version": "1.0.2",
@@ -5687,14 +5193,12 @@
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5705,21 +5209,13 @@
     "node_modules/jsbi": {
       "version": "4.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsbi/-/jsbi-4.3.0.tgz",
-      "integrity": "sha1-tU7gdPtvy8AGGVWTBcj36RKwR0E=",
-      "license": "Apache-2.0"
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "license": "MIT"
+      "integrity": "sha1-tU7gdPtvy8AGGVWTBcj36RKwR0E="
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -5730,46 +5226,29 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
-      "license": "MIT"
+      "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM="
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha1-995M9u+rg4666zI2R0y7paGTCrU=",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
-      "license": "MIT"
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "license": "ISC"
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json5/-/json5-2.2.3.tgz",
       "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5781,7 +5260,6 @@
       "version": "9.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha1-Zf+R9KvvF4RpfUCVK7GZjFBMqvM=",
-      "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -5799,26 +5277,10 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha1-SDmG7E7TjhxsSMNIlKkYLb/2im4=",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5826,46 +5288,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
-      "license": "ISC"
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha1-cSxlUzoVyHi6WentXw4m1bd8X+s=",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/jsprim/node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
     "node_modules/jstransformer": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jstransformer/-/jstransformer-1.0.0.tgz",
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
-      "license": "MIT",
       "dependencies": {
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
@@ -5875,7 +5301,6 @@
       "version": "1.4.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
-      "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -5886,7 +5311,6 @@
       "version": "3.2.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-3.2.2.tgz",
       "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
-      "license": "MIT",
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -5896,7 +5320,6 @@
       "version": "4.5.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=",
-      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -5906,7 +5329,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5916,7 +5338,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/leven/-/leven-3.1.0.tgz",
       "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5925,7 +5346,6 @@
       "version": "0.4.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/levn/-/levn-0.4.1.tgz",
       "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -5938,14 +5358,12 @@
       "version": "1.2.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -5959,68 +5377,57 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
-      "license": "MIT"
+      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "license": "MIT"
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
-      "license": "MIT"
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
-      "license": "MIT"
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
-      "license": "MIT"
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
-      "license": "MIT"
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "license": "MIT"
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "license": "MIT"
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
-      "license": "MIT"
+      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "license": "MIT"
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
-      "license": "MIT",
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -6030,15 +5437,13 @@
       "version": "4.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
-      "license": "MIT",
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0"
       }
     },
     "node_modules/login.dfe.async-retry": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.async-retry.git#ba591c07b1439f5075ba29cd0e4efda3f529b3be",
-      "license": "MIT",
+      "version": "2.0.3",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.async-retry.git#72c42369276361f6cdeaabc331100f50b4a10dbf",
       "dependencies": {
         "retry": "^0.13.1"
       }
@@ -6046,7 +5451,6 @@
     "node_modules/login.dfe.config.schema.common": {
       "version": "1.9.1",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.config.schema.common.git#3c88abb30251262bb3d05622436c5da5831266cd",
-      "license": "MIT",
       "dependencies": {
         "simpl-schema": "^1.5.6"
       }
@@ -6055,7 +5459,6 @@
       "version": "4.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-4.2.0.tgz",
       "integrity": "sha1-4hGcySeLeKbq12s4zRSuV2wbZHg=",
-      "license": "ISC",
       "dependencies": {
         "eslint": "^8.12.0",
         "express": "^4.17.3",
@@ -6073,7 +5476,6 @@
     "node_modules/login.dfe.jwt-strategies": {
       "version": "3.0.1",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#10a7098d6f7aff992d5903d755ba537849ae2f4b",
-      "license": "MIT",
       "dependencies": {
         "adal-node": "^0.2.3",
         "memory-cache": "^0.2.0"
@@ -6083,7 +5485,6 @@
       "name": "kue",
       "version": "0.11.6",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.kue.git#34b29db0b31364ac932c21dffa3eeaf8607c55f3",
-      "license": "MIT",
       "dependencies": {
         "body-parser": "^1.12.2",
         "express": "^4.12.2",
@@ -6102,22 +5503,11 @@
         "reds": "^1.0.0"
       }
     },
-    "node_modules/login.dfe.request-promise-retry": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.request-promise-retry.git#cedf7a91a4c7e1d51f51389c4ff3c2aa4273aa1d",
-      "license": "MIT",
-      "dependencies": {
-        "login.dfe.async-retry": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#v2.0.0",
-        "request": "^2.88.0",
-        "request-promise": "^4.2.3"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -6127,7 +5517,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha1-w8IwencSd82WODBfkVwprnQbYU4=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -6138,28 +5527,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-dir/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha1-SDmG7E7TjhxsSMNIlKkYLb/2im4=",
+      "version": "7.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6167,19 +5539,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/make-dir/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/makeerror/-/makeerror-1.0.12.tgz",
       "integrity": "sha1-Pl3SB5qC6BLpg8xmEMSiyw6qgBo=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
       }
@@ -6199,7 +5563,6 @@
       "version": "0.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6207,27 +5570,23 @@
     "node_modules/memory-cache": {
       "version": "0.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/memory-cache/-/memory-cache-0.2.0.tgz",
-      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo=",
-      "license": "BSD-2-Clause"
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "license": "MIT"
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/message-box": {
       "version": "0.2.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/message-box/-/message-box-0.2.7.tgz",
       "integrity": "sha1-e6s0L+Cw7aJG0UkKaW6WWl55GIo=",
-      "license": "MIT",
       "dependencies": {
         "lodash.template": "^4.5.0"
       }
@@ -6236,19 +5595,17 @@
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha1-vImZp8u/d83InxMvbkZwUbSQkMY=",
+      "version": "4.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha1-M+gZDZ/kdKmJVSX1YY7uE21GwuU=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -6259,7 +5616,6 @@
       "version": "1.6.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime/-/mime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
-      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -6271,7 +5627,6 @@
       "version": "1.52.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6280,7 +5635,6 @@
       "version": "2.1.35",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
-      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6293,7 +5647,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6302,7 +5655,6 @@
       "version": "3.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6314,7 +5666,6 @@
       "version": "1.2.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6323,7 +5674,6 @@
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
-      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -6332,19 +5682,17 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha1-Pb4FKIn+fBsu2Wb8s6dzKJZO8Qg=",
-      "license": "MIT",
+      "version": "2.30.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha1-+MkcB7enhuMMWZJt9TC06slpdK4=",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.43",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment-timezone/-/moment-timezone-0.5.43.tgz",
-      "integrity": "sha1-Pdfz0MZ/eMI80ZBrmyE3oJs8R5A=",
-      "license": "MIT",
+      "version": "0.5.45",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha1-y2hazVa6wQ5p2TxTY2brZaprz1w=",
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -6355,26 +5703,22 @@
     "node_modules/mongo-object": {
       "version": "0.1.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mongo-object/-/mongo-object-0.1.4.tgz",
-      "integrity": "sha1-lQ0dhWuFr18jIbgrsItnucJ/l2Y=",
-      "license": "MIT"
+      "integrity": "sha1-lQ0dhWuFr18jIbgrsItnucJ/l2Y="
     },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-      "license": "MIT"
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
     },
     "node_modules/native-duplexpair": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
-      "integrity": "sha1-eJkHjmS/PIo9cyYBs9QP8F21j6A=",
-      "license": "MIT"
+      "integrity": "sha1-eJkHjmS/PIo9cyYBs9QP8F21j6A="
     },
     "node_modules/natural": {
       "version": "0.5.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/natural/-/natural-0.5.0.tgz",
       "integrity": "sha1-Vam7aOzPXs5VNUhgBKV94mSuMYA=",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "apparatus": ">= 0.0.9",
@@ -6388,14 +5732,12 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "license": "MIT"
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha1-WOMjpy/twNb5zU0x/kn1FHlZDM0=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6404,7 +5746,6 @@
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nib/-/nib-1.1.2.tgz",
       "integrity": "sha1-amnt5AgblcDe+L4CSkyK4MLLtsc=",
-      "license": "MIT",
       "dependencies": {
         "stylus": "0.54.5"
       },
@@ -6415,14 +5756,12 @@
     "node_modules/nib/node_modules/css-parse": {
       "version": "1.7.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/css-parse/-/css-parse-1.7.0.tgz",
-      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=",
-      "license": "MIT"
+      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs="
     },
     "node_modules/nib/node_modules/glob": {
       "version": "7.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-7.0.6.tgz",
       "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6439,7 +5778,6 @@
       "version": "0.5.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -6450,8 +5788,7 @@
     "node_modules/nib/node_modules/sax": {
       "version": "0.5.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sax/-/sax-0.5.8.tgz",
-      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
-      "license": "BSD"
+      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
     },
     "node_modules/nib/node_modules/source-map": {
       "version": "0.1.43",
@@ -6468,7 +5805,6 @@
       "version": "0.54.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stylus/-/stylus-0.54.5.tgz",
       "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
-      "license": "MIT",
       "dependencies": {
         "css-parse": "1.7.x",
         "debug": "*",
@@ -6487,44 +5823,38 @@
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg=",
-      "license": "MIT"
+      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg="
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/node-redis-script": {
       "version": "2.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-redis-script/-/node-redis-script-2.0.1.tgz",
-      "integrity": "sha1-qRhOo225BPrGoM4Oe267btEHhPE=",
-      "license": "MIT"
+      "integrity": "sha1-qRhOo225BPrGoM4Oe267btEHhPE="
     },
     "node_modules/node-redis-warlock": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-redis-warlock/-/node-redis-warlock-1.0.2.tgz",
       "integrity": "sha1-fCVobWfTVO5gG6lLb90p9ofex2w=",
-      "license": "MIT",
       "dependencies": {
         "node-redis-script": "^2.0.1",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha1-1e0WJ8I+NGHoGbAuV7deSJmxyB0=",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha1-L/sFO864sr6Elezhq2zmAMRGGws=",
+      "dev": true
     },
     "node_modules/nopt": {
       "version": "2.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nopt/-/nopt-2.1.2.tgz",
       "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
-      "license": "MIT (https://github.com/isaacs/nopt/raw/master/LICENSE)",
       "dependencies": {
         "abbrev": "1"
       },
@@ -6537,7 +5867,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6565,25 +5894,11 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/notifications-node-client/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -6591,20 +5906,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6613,7 +5918,6 @@
       "version": "1.13.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha1-uWxhCTJMz+9rEiFqlWyk3C/5S8I=",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6622,19 +5926,17 @@
       "version": "1.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha1-lnPHx8NRq4xNC1FvQ0Pr9N+3eZ8=",
-      "license": "MIT",
+      "version": "4.1.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha1-OoM/mrf9uA/J6NIwDIA9IW2P27A=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
@@ -6646,30 +5948,29 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.entries/-/object.entries-1.1.7.tgz",
-      "integrity": "sha1-K0d2DiouOnUvOd2HRlXGGn8DwTE=",
+      "version": "1.1.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.entries/-/object.entries-1.1.8.tgz",
+      "integrity": "sha1-v/5vKC4B9NF4ByBKJPjt2CNZnEE=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.fromentries/-/object.fromentries-2.0.7.tgz",
-      "integrity": "sha1-celfRB6aDqa69oLsqvN/oqjX5hY=",
+      "version": "2.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha1-9xldipuXvZXLwZmeqTns0aKwDGU=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6679,28 +5980,28 @@
       }
     },
     "node_modules/object.groupby": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.groupby/-/object.groupby-1.0.1.tgz",
-      "integrity": "sha1-1B2fPI1sd42cushrTun1rxAxUu4=",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha1-mxJcNiOBKfb3thlUoecXYUjVAC4=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.values/-/object.values-1.1.7.tgz",
-      "integrity": "sha1-YX7RMnLn4QcbQ5c6oWVdkpG4RCo=",
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.values/-/object.values-1.2.0.tgz",
+      "integrity": "sha1-ZUBanZLO5orC0wMALguEcKTZqxs=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6713,7 +6014,6 @@
       "version": "2.4.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha1-WMjEQRblSEWtV/FKsQsDUzGErD8=",
-      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -6725,7 +6025,6 @@
       "version": "1.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -6735,7 +6034,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -6750,7 +6048,6 @@
       "version": "8.4.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/open/-/open-8.4.2.tgz",
       "integrity": "sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk=",
-      "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -6764,17 +6061,16 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha1-AHOX1E7Rhy/cbtMTYBkPgYFOLGQ=",
-      "license": "MIT",
+      "version": "0.9.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=",
       "dependencies": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -6784,7 +6080,6 @@
       "version": "3.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -6799,7 +6094,6 @@
       "version": "5.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -6815,7 +6109,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6824,7 +6117,6 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
-      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -6837,7 +6129,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -6855,7 +6146,6 @@
       "version": "1.3.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6864,7 +6154,6 @@
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -6873,7 +6162,6 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6882,7 +6170,6 @@
       "version": "3.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -6890,40 +6177,29 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "license": "MIT"
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "license": "MIT"
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "license": "MIT"
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/pg-connection-string": {
-      "version": "2.6.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-      "integrity": "sha1-cT2CBT3k4r0Wb6twzU8mrTaqtHU=",
-      "license": "MIT"
+      "version": "2.6.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha1-9UOGKt+kn6ThS8ioiS0qhNdUJG0="
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw=",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha1-qK1Xm1cZUvDl0liS3lRFvP4lqqE=",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6936,7 +6212,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha1-MBiuMuz8/2wpuiJny/IRZqwfNrk=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -6946,7 +6221,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -6959,7 +6233,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -6973,7 +6246,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -6986,7 +6258,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -7002,7 +6273,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -7010,11 +6280,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha1-ibtjxvraLD6QrcSmR77us5zHv48=",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -7024,7 +6301,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha1-ykLHWDEPNlv6caC9oKgHFgt3aBI=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -7039,7 +6315,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7051,7 +6326,6 @@
       "version": "7.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/promise/-/promise-7.3.1.tgz",
       "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
-      "license": "MIT",
       "dependencies": {
         "asap": "~2.0.3"
       }
@@ -7061,7 +6335,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha1-e1fnOzpIAprRDr1E90sBcipMsGk=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
@@ -7074,7 +6347,6 @@
       "version": "2.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=",
-      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -7087,12 +6359,6 @@
       "version": "1.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I="
-    },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha1-0N8qE38AeUVl/K87LADNCfjVpac=",
-      "license": "MIT"
     },
     "node_modules/pug": {
       "version": "3.0.3",
@@ -7143,7 +6409,6 @@
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-filters/-/pug-filters-4.0.0.tgz",
       "integrity": "sha1-0+Sa9bqEcum3pm2YDnB86dLMm14=",
-      "license": "MIT",
       "dependencies": {
         "constantinople": "^4.0.1",
         "jstransformer": "1.0.0",
@@ -7156,7 +6421,6 @@
       "version": "5.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-lexer/-/pug-lexer-5.0.1.tgz",
       "integrity": "sha1-rkRijFvvmxkLZlaDsojKkCS4sNU=",
-      "license": "MIT",
       "dependencies": {
         "character-parser": "^2.2.0",
         "is-expression": "^4.0.0",
@@ -7167,7 +6431,6 @@
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-linker/-/pug-linker-4.0.0.tgz",
       "integrity": "sha1-EsvAWU/Fo+Brn8Web5PBRpYqdwg=",
-      "license": "MIT",
       "dependencies": {
         "pug-error": "^2.0.0",
         "pug-walk": "^2.0.0"
@@ -7177,7 +6440,6 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-load/-/pug-load-3.0.0.tgz",
       "integrity": "sha1-n9nNpSICsIrbEdJWgfufNL1BtmI=",
-      "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.1",
         "pug-walk": "^2.0.0"
@@ -7187,7 +6449,6 @@
       "version": "6.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-parser/-/pug-parser-6.0.0.tgz",
       "integrity": "sha1-qP3ANYY6lbLB3F6/Ts+AtOdqEmA=",
-      "license": "MIT",
       "dependencies": {
         "pug-error": "^2.0.0",
         "token-stream": "1.0.0"
@@ -7202,7 +6463,6 @@
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
       "integrity": "sha1-+UsH/WtJVSMzD0kKf1VLT/h2MD4=",
-      "license": "MIT",
       "dependencies": {
         "pug-error": "^2.0.0"
       }
@@ -7210,22 +6470,20 @@
     "node_modules/pug-walk": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-walk/-/pug-walk-2.0.0.tgz",
-      "integrity": "sha1-QXqrwpIyu0SZtbUGmistKiTV9f4=",
-      "license": "MIT"
+      "integrity": "sha1-QXqrwpIyu0SZtbUGmistKiTV9f4="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pure-rand/-/pure-rand-6.0.4.tgz",
-      "integrity": "sha1-ULc39qklRoZ5v/AK0g6t5T831cc=",
+      "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha1-0XPPIyWCMZdsy9sFJHyXh5V2BPI=",
       "dev": true,
       "funding": [
         {
@@ -7236,14 +6494,12 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fast-check"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.11.0.tgz",
       "integrity": "sha1-/Q2WNEb3pl4TZ+AavYVClFPww3o=",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -7279,14 +6535,12 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7306,17 +6560,15 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha1-GZQx7qqi4J+GQn77tPFHPttHYJs=",
-      "dev": true,
-      "license": "MIT"
+      "version": "18.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha1-6DVX3BLq5jqZ4AOkY4ix3LtE234=",
+      "dev": true
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7330,7 +6582,6 @@
       "version": "3.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis/-/redis-3.1.2.tgz",
       "integrity": "sha1-dmhREX6AZT0j4O1TYlRnerZHY4w=",
-      "license": "MIT",
       "dependencies": {
         "denque": "^1.5.0",
         "redis-commands": "^1.7.0",
@@ -7348,14 +6599,12 @@
     "node_modules/redis-commands": {
       "version": "1.7.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha1-Fab+otWCgeJ7HNGs+0spPieMOok=",
-      "license": "MIT"
+      "integrity": "sha1-Fab+otWCgeJ7HNGs+0spPieMOok="
     },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -7364,7 +6613,6 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
-      "license": "MIT",
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -7386,7 +6634,6 @@
       "version": "2.8.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis/-/redis-2.8.0.tgz",
       "integrity": "sha1-ICKI4/WMSfYHnZevehDhMDrhSwI=",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "double-ended-queue": "^2.1.0-0",
@@ -7401,21 +6648,20 @@
       "version": "2.6.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-parser/-/redis-parser-2.6.0.tgz",
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-      "integrity": "sha1-kM6YkTjbIJ+BSS7dc0GDzpn5Z34=",
-      "license": "MIT",
+      "version": "1.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha1-E49kSjNQ+YGoWMRPa7GmH/Wb4zQ=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "set-function-name": "^2.0.0"
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7424,93 +6670,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/request/-/request-2.88.2.tgz",
-      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise": {
-      "version": "4.2.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha1-fn5blXhjDm9ZjjgTwPjrNCon8KI=",
-      "license": "ISC",
-      "dependencies": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha1-Ou7/yRln7241wOSI70b7KWq3aq0=",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7519,7 +6682,6 @@
       "version": "1.22.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha1-tsh6nyqgbfq1Lj1wrIzeMh+lpI0=",
-      "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -7537,7 +6699,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
       },
@@ -7550,7 +6711,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7559,7 +6719,6 @@
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -7567,15 +6726,13 @@
     "node_modules/resolve-url": {
       "version": "0.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "license": "MIT"
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve.exports/-/resolve.exports-2.0.2.tgz",
       "integrity": "sha1-+Mk0uOahP1OeOLcJji42E08B6AA=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -7584,7 +6741,6 @@
       "version": "0.13.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/retry/-/retry-0.13.1.tgz",
       "integrity": "sha1-GFsVh6z2eRnWOzVzSeA1N7JIRlg=",
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -7592,14 +6748,12 @@
     "node_modules/retry-as-promised": {
       "version": "7.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
-      "integrity": "sha1-nfc62u6gjLKUi500mQVJ3BPYAKI=",
-      "license": "MIT"
+      "integrity": "sha1-nfc62u6gjLKUi500mQVJ3BPYAKI="
     },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
-      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -7609,7 +6763,6 @@
       "version": "3.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
-      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7638,19 +6791,17 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-      "integrity": "sha1-kWhqY8462+oU1hsUyZVyqP+EdUw=",
-      "license": "MIT",
+      "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha1-gdd+4MTouGNjUifHISeN1STCDts=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -7664,8 +6815,7 @@
     "node_modules/safe-array-concat/node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
-      "license": "MIT"
+      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -7684,18 +6834,19 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha1-eTuHTVJOs2QNGHOq0DWW2y1PIpU=",
-      "license": "MIT",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha1-pbTA8G4KtQ6iw5XBTYNxIykkw3c=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7704,20 +6855,17 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
-      "license": "MIT"
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "node_modules/sax": {
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
-      "license": "ISC"
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-6.3.1.tgz",
       "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -7726,7 +6874,6 @@
       "version": "0.18.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/send/-/send-0.18.0.tgz",
       "integrity": "sha1-ZwFnzGVLBfWqSnZ/kRO7NxvHBr4=",
-      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -7750,7 +6897,6 @@
       "version": "2.6.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -7758,26 +6904,23 @@
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "license": "MIT"
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "license": "MIT"
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
     },
     "node_modules/sequelize": {
-      "version": "6.34.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.34.0.tgz",
-      "integrity": "sha1-A6MVuvuvUNFK+WibLzeYXVEHKvA=",
+      "version": "6.37.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.3.tgz",
+      "integrity": "sha1-7WISAppSxZoYY40qcD2oS8L4ExE=",
       "funding": [
         {
           "type": "opencollective",
           "url": "https://opencollective.com/sequelize"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
@@ -7833,7 +6976,6 @@
       "version": "0.10.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize-mock/-/sequelize-mock-0.10.2.tgz",
       "integrity": "sha1-GdOXHM2utbhkFwwkznkqinHxRL0=",
-      "license": "MIT",
       "dependencies": {
         "bluebird": "^3.4.6",
         "inflection": "^1.10.0",
@@ -7844,31 +6986,14 @@
       "version": "7.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
       "integrity": "sha1-IQs5GvQAJ2L4IxiP1uz8dBMCB2g=",
-      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/sequelize/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/sequelize/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha1-SDmG7E7TjhxsSMNIlKkYLb/2im4=",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7876,17 +7001,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/sequelize/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
-      "license": "ISC"
-    },
     "node_modules/serve-static": {
       "version": "1.15.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/serve-static/-/serve-static-1.15.0.tgz",
       "integrity": "sha1-+q7wjP/goaYvYMrQxOUTz/CslUA=",
-      "license": "MIT",
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -7898,29 +7016,30 @@
       }
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha1-S8Ofr7AwciSjPhBqfTXKEhjWWe0=",
-      "license": "MIT",
+      "version": "1.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha1-qscjFBmOrtl1z3eyw7a4gGleVEk=",
       "dependencies": {
-        "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/set-function-name": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-name/-/set-function-name-2.0.1.tgz",
-      "integrity": "sha1-Es44t5VDELn2H6oScBYgoMiCeTo=",
-      "license": "MIT",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha1-FqcFxaDcL15jjKltiozU4cK5CYU=",
       "dependencies": {
-        "define-data-property": "^1.0.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7929,14 +7048,12 @@
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha1-ZsmiSnP5/CjL5msJ/tPTPcrxtCQ=",
-      "license": "ISC"
+      "integrity": "sha1-ZsmiSnP5/CjL5msJ/tPTPcrxtCQ="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
-      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -7948,20 +7065,22 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
-      "license": "MIT",
+      "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha1-q9Jft80kuvRUZkBrEJa3gxySFfI=",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7971,14 +7090,12 @@
       "version": "3.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/simpl-schema": {
       "version": "1.13.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/simpl-schema/-/simpl-schema-1.13.1.tgz",
       "integrity": "sha1-roVOMnJTcQlA3Aj+91hltLGS2yw=",
-      "license": "MIT",
       "dependencies": {
         "clone": "^2.1.2",
         "message-box": "^0.2.7",
@@ -7989,15 +7106,13 @@
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/slash/-/slash-3.0.0.tgz",
       "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -8006,7 +7121,6 @@
       "version": "0.6.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8015,7 +7129,6 @@
       "version": "0.5.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
-      "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
@@ -8029,7 +7142,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -8038,41 +7150,18 @@
     "node_modules/source-map-url": {
       "version": "0.4.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY=",
-      "license": "MIT"
+      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY="
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha1-SRS5A6L4toXRf994pw6RfocuREo=",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha1-FmPlXN301oi4aka3fw1f42OroCg=",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha1-SRS5A6L4toXRf994pw6RfocuREo="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha1-qvB0gWnAL8M8gjKrzPkz9Uocw08=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -8085,7 +7174,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -8094,25 +7182,14 @@
       "version": "2.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha1-VcsADM8dSHKL0jxoWgY5mM8aG2M=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stoppable": {
       "version": "1.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stoppable/-/stoppable-1.1.0.tgz",
       "integrity": "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs=",
-      "license": "MIT",
       "engines": {
         "node": ">=4",
         "npm": ">=6"
@@ -8122,7 +7199,6 @@
       "version": "1.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -8132,7 +7208,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-length/-/string-length-4.0.2.tgz",
       "integrity": "sha1-qKjce9XBqCubPIuH4SX2aHG25Xo=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
@@ -8145,7 +7220,6 @@
       "version": "4.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8156,14 +7230,14 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-      "integrity": "sha1-+axvivS9Vd36iJXmrqkqljlTk70=",
-      "license": "MIT",
+      "version": "1.2.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+      "integrity": "sha1-tvoybXLSx4tt8C93Wcc/j2J0+qQ=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8173,28 +7247,29 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-      "integrity": "sha1-G7OvxQCGYdc+LcAVzUhTcy1sRx4=",
-      "license": "MIT",
+      "version": "1.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+      "integrity": "sha1-NlG4UTcZ6Kn0jefy93ZAsmZSsik=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-      "integrity": "sha1-1M20S4Okc3/7rC1AbkBdQ9AYQpg=",
-      "license": "MIT",
+      "version": "1.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8204,7 +7279,6 @@
       "version": "6.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8217,7 +7291,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -8227,7 +7300,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8236,7 +7308,6 @@
       "version": "3.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -8248,7 +7319,6 @@
       "version": "0.54.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stylus/-/stylus-0.54.8.tgz",
       "integrity": "sha1-PaPmWWa8Vnp7BEv+DuzmU+CZ0Uc=",
-      "license": "MIT",
       "dependencies": {
         "css-parse": "~2.0.0",
         "debug": "~3.1.0",
@@ -8270,7 +7340,6 @@
       "version": "3.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.1.0.tgz",
       "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8278,20 +7347,17 @@
     "node_modules/stylus/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "license": "MIT"
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/stylus/node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
-      "license": "ISC"
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "node_modules/stylus/node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map/-/source-map-0.7.4.tgz",
       "integrity": "sha1-qbvnBcnYhG9OCP9nZazw8bCJhlY=",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
       }
@@ -8300,7 +7366,6 @@
       "version": "7.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -8312,7 +7377,6 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -8333,7 +7397,6 @@
       "version": "14.7.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-14.7.0.tgz",
       "integrity": "sha1-QSbqtoqj8k70JAby50r1qpa2TlA=",
-      "license": "MIT",
       "dependencies": {
         "@azure/identity": "^2.0.4",
         "@azure/keyvault-keys": "^4.4.0",
@@ -8357,7 +7420,6 @@
       "version": "0.6.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
-      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -8370,7 +7432,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
@@ -8383,21 +7444,18 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "license": "MIT"
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha1-hoPguQK7nCDE9ybjwLafNlGMB8w=",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "dev": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -8407,7 +7465,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -8419,7 +7476,6 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha1-O+NDIaiKgg7RvYDfqjPkefu43TU=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -8427,34 +7483,18 @@
     "node_modules/token-stream": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/token-stream/-/token-stream-1.0.0.tgz",
-      "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ=",
-      "license": "MIT"
+      "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ="
     },
     "node_modules/toposort-class": {
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/toposort-class/-/toposort-class-1.0.1.tgz",
-      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg=",
-      "license": "MIT"
-    },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha1-bjLx95QS3s0mH5LWM6ncHPqZ8Ig=",
+      "version": "3.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha1-UpnsYF5VsauyPsk57xXtr0gwcNQ=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.2",
@@ -8467,7 +7507,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json5/-/json5-1.0.2.tgz",
       "integrity": "sha1-Y9mNYPIbMTt3xNbaGL+mnYDh1ZM=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -8480,7 +7519,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -8488,32 +7526,12 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha1-cDrClCXns3zW/UVukkBNRtHz5K4=",
-      "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "license": "Unlicense"
+      "integrity": "sha1-cDrClCXns3zW/UVukkBNRtHz5K4="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -8526,7 +7544,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -8535,7 +7552,6 @@
       "version": "0.20.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -8547,7 +7563,6 @@
       "version": "1.6.18",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
-      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -8557,29 +7572,28 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
-      "integrity": "sha1-GN4+fteXSwpynT/uy5QzjRRyzWA=",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha1-GGfF2Dsg/LXM8yZJ5eL8dCRHT/M=",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
-        "is-typed-array": "^1.1.10"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-      "integrity": "sha1-14eiSplXEWEfsrh6QFJ5lReyMNA=",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha1-2Sly08/5mj+i52Wij83A8did7Gc=",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8589,16 +7603,16 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
-      "integrity": "sha1-y76JtR/e+c1qrwetRwc0CrvE6gs=",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha1-+eway5JZ85UJPkVn6zwopYDQIGM=",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8608,14 +7622,19 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-length/-/typed-array-length-1.0.4.tgz",
-      "integrity": "sha1-idg3heXECYvscuCLMZZR8OrJwbs=",
-      "license": "MIT",
+      "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-length/-/typed-array-length-1.0.6.tgz",
+      "integrity": "sha1-VxVSB8duZKNFdILf3BydHTxMc6M=",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "is-typed-array": "^1.1.9"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8625,7 +7644,6 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -8639,28 +7657,25 @@
     "node_modules/underscore": {
       "version": "1.13.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha1-BHhqH1idxsCfdh/F9FuJ6TUTZEE=",
-      "license": "MIT"
+      "integrity": "sha1-BHhqH1idxsCfdh/F9FuJ6TUTZEE="
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha1-vNU5iT0AtW6WT9JlekhmsiGmVhc=",
-      "license": "MIT"
+      "integrity": "sha1-vNU5iT0AtW6WT9JlekhmsiGmVhc="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha1-PF5PXAg2Yb0472S2Mowm7WyCSMQ=",
+      "version": "1.0.16",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+      "integrity": "sha1-9tSJ7ZD7LwfWd4TrP1PXiR9zY1Y=",
       "dev": true,
       "funding": [
         {
@@ -8676,10 +7691,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -8692,7 +7706,6 @@
       "version": "4.4.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -8700,14 +7713,12 @@
     "node_modules/urix": {
       "version": "0.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "license": "MIT"
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "node_modules/url": {
       "version": "0.10.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "license": "MIT",
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -8716,14 +7727,12 @@
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "license": "MIT"
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/util/-/util-0.12.5.tgz",
       "integrity": "sha1-XxemBZtz22GodWaHgaHCsTa9b7w=",
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -8735,14 +7744,12 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "license": "MIT"
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -8751,17 +7758,15 @@
       "version": "8.3.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-      "integrity": "sha1-6kVmBBAc0YAFrCyuPN0aoFimMGs=",
+      "version": "9.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha1-LtdkSiRc3dg9Tgh7mzOz5i39EK0=",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -8772,10 +7777,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.11.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/validator/-/validator-13.11.0.tgz",
-      "integrity": "sha1-I6s/1ZKQxhJINk6r9AZ/BJVfuxs=",
-      "license": "MIT",
+      "version": "13.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha1-fXjna6hVBNo/7k/Rkis4WRTUs18=",
       "engines": {
         "node": ">= 0.10"
       }
@@ -8784,7 +7788,6 @@
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8793,7 +7796,6 @@
       "version": "1.10.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/verror/-/verror-1.10.1.tgz",
       "integrity": "sha1-S/Ce7M9FY7EJ7Us9RYOAyXKwzes=",
-      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -8816,7 +7818,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/walker/-/walker-1.0.8.tgz",
       "integrity": "sha1-vUmNtHev5XPcBBhfAR06uKjXZT8=",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
       }
@@ -8825,7 +7826,6 @@
       "version": "2.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
-      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -8840,7 +7840,6 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
-      "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -8853,16 +7852,15 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-typed-array/-/which-typed-array-1.1.13.tgz",
-      "integrity": "sha1-hwzVvgbdthb1BOewOcTCSJgYTTY=",
-      "license": "MIT",
+      "version": "1.1.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha1-JkhZ6bEaZJs4i/qvT3Z98fd5s40=",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8889,16 +7887,22 @@
       "version": "0.5.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wkx/-/wkx-0.5.0.tgz",
       "integrity": "sha1-xsNwGaz0DlF8xrlGV6JaPUqjPow=",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -8914,15 +7918,13 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "license": "ISC"
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha1-qd8Brlt3hYoCf9LoB2juQzVV/P0=",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -8932,10 +7934,9 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha1-2UQGMfuy7YACA/rRBvJyT2LEk7c=",
-      "license": "MIT",
+      "version": "0.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha1-3QtjAIOqCcFh4lpNCQHisqkptJk=",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -8948,7 +7949,6 @@
       "version": "11.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM=",
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -8957,7 +7957,6 @@
       "version": "1.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/xpath.js/-/xpath.js-1.1.0.tgz",
       "integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8966,7 +7965,6 @@
       "version": "5.0.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
-      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -8975,14 +7973,12 @@
       "version": "3.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
-      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -9000,7 +7996,6 @@
       "version": "21.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -9009,7 +8004,6 @@
       "version": "0.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "login.dfe.dao": "4.2.0",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
         "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
-        "markdown": "^0.5.0",
+        "marked": "^12.0.2",
         "notifications-node-client": "^7.0.0",
         "uuid": "^8.3.2"
       },
@@ -256,6 +256,35 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@azure/identity/node_modules/@azure/msal-common": {
+      "version": "7.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-7.6.0.tgz",
+      "integrity": "sha1-tS6X71QCdfcmEc/1eTffoLNM3Mo=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-node": {
+      "version": "1.18.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
+      "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
+      "dependencies": {
+        "@azure/msal-common": "13.3.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": "10 || 12 || 14 || 16 || 18"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "13.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
+      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@azure/identity/node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/events/-/events-3.3.0.tgz",
@@ -335,32 +364,24 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "7.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-7.6.0.tgz",
-      "integrity": "sha1-tS6X71QCdfcmEc/1eTffoLNM3Mo=",
+      "version": "14.10.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.10.0.tgz",
+      "integrity": "sha1-IVRJcmcXtT1UmVPbd1YsrWy4Qhw=",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "1.18.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
-      "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
+      "version": "2.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.9.0.tgz",
+      "integrity": "sha1-4G1FzrgLj2idcAfFMAsB/Slm1pU=",
       "dependencies": {
-        "@azure/msal-common": "13.3.1",
+        "@azure/msal-common": "14.10.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": "10 || 12 || 14 || 16 || 18"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
-      "engines": {
-        "node": ">=0.8.0"
+        "node": ">=16"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1604,9 +1625,9 @@
       "integrity": "sha1-EJZLoN7mrEzUYuJ5W2vr1AcwNDM="
     },
     "node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha1-fL7N+QIIXOxjT9s2IXLf4SuPIFA=",
+      "version": "20.12.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.12.13.tgz",
+      "integrity": "sha1-kO07ik5S3TxdxaQt3luFt0rY7Yg=",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1641,11 +1662,6 @@
       "version": "1.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha1-dWZBrbWHhRtcyz4JXa8nrlgchAY="
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -1950,9 +1966,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1628.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/aws-sdk/-/aws-sdk-2.1628.0.tgz",
-      "integrity": "sha1-fSk4fg0VncjpaYla27lWZPmwfOE=",
+      "version": "2.1631.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/aws-sdk/-/aws-sdk-2.1631.0.tgz",
+      "integrity": "sha1-x3LBUKIHsKjpebaEf2pjZ21RVzA=",
       "hasInstallScript": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -1976,6 +1992,16 @@
       "integrity": "sha1-vGzPkbX/CsB7vNvxx8ThUNtNu2w=",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha1-tiXbinBR++phw1o8uzodqnucdiE=",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2340,9 +2366,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001624",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001624.tgz",
-      "integrity": "sha1-DsTI+npG5beFR3xws4pW0LEAWOs=",
+      "version": "1.0.30001625",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001625.tgz",
+      "integrity": "sha1-6tGxVeppHWqHk4dU08sRnCRGWwM=",
       "dev": true,
       "funding": [
         {
@@ -2832,9 +2858,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.783",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.783.tgz",
-      "integrity": "sha1-kziHFluLYCWoFmPS2Xz0uFzeJ7I=",
+      "version": "1.4.787",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.787.tgz",
+      "integrity": "sha1-Pu3Qo7i+K56W4hZ105l4atkLme0=",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5404,27 +5430,6 @@
         "@azure/msal-node": "^2.6.4"
       }
     },
-    "node_modules/login.dfe.jwt-strategies/node_modules/@azure/msal-common": {
-      "version": "14.10.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.10.0.tgz",
-      "integrity": "sha1-IVRJcmcXtT1UmVPbd1YsrWy4Qhw=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/login.dfe.jwt-strategies/node_modules/@azure/msal-node": {
-      "version": "2.8.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.8.1.tgz",
-      "integrity": "sha1-re0o037qLnJ4yb1E8gFmRzkPI5w=",
-      "dependencies": {
-        "@azure/msal-common": "14.10.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/login.dfe.kue": {
       "name": "kue",
       "version": "0.12.0",
@@ -5489,15 +5494,15 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/markdown": {
-      "version": "0.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/markdown/-/markdown-0.5.0.tgz",
-      "integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
-      "dependencies": {
-        "nopt": "~2.1.1"
-      },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha1-sxV4/mCLWZlExpgHsA8Y7auEZH4=",
       "bin": {
-        "md2html": "bin/md2html.js"
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/media-typer": {
@@ -5773,17 +5778,6 @@
       "integrity": "sha1-L/sFO864sr6Elezhq2zmAMRGGws=",
       "dev": true
     },
-    "node_modules/nopt": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nopt/-/nopt-2.1.2.tgz",
-      "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5804,16 +5798,6 @@
       "engines": {
         "node": ">=14.17.3",
         "npm": ">=6.14.13"
-      }
-    },
-    "node_modules/notifications-node-client/node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha1-tiXbinBR++phw1o8uzodqnucdiE=",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/npm-run-path": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "jest-cli": "^29.6.3"
       },
       "engines": {
-        "node": "18.17.0"
+        "node": "18.x.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2159,8 +2159,7 @@
     "node_modules/assert-never": {
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/assert-never/-/assert-never-1.2.1.tgz",
-      "integrity": "sha1-EfDjY78UYgX7CBk7XHuQ9NHPRP4=",
-      "license": "MIT"
+      "integrity": "sha1-EfDjY78UYgX7CBk7XHuQ9NHPRP4="
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
@@ -2378,7 +2377,6 @@
       "version": "3.0.0-canary-5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
       "integrity": "sha1-9m7Ncpg1eu5ElV8jWm71QhkQSxE=",
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.9.6"
       },
@@ -2483,13 +2481,12 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha1-sYEqiRLBlc03Gj7l5m+qIzilxmg=",
-      "license": "MIT",
+      "version": "1.20.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha1-b+sOIcRyTQbef/ONo22tT1enR/0=",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -2497,7 +2494,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -2615,7 +2612,6 @@
       "version": "3.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha1-iwvuuYYFrfGxKPpDhkA8AJ4CIaU=",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2861,10 +2857,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha1-0fXXGt7GVYxY84mYfDZqpH6ZT4s=",
-      "license": "MIT",
+      "version": "0.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha1-J5iwSwcbDsv/DbtipQWo76ThkFE=",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3128,8 +3123,7 @@
     "node_modules/doctypes": {
       "version": "1.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
-      "license": "MIT"
+      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "node_modules/dottie": {
       "version": "2.0.6",
@@ -3170,10 +3164,9 @@
       "license": "MIT"
     },
     "node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha1-A8nod3/hJoap7/zvIjA8o9jus2E=",
-      "license": "Apache-2.0",
+      "version": "3.1.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha1-aauDWLFOiW+AzDnmIIe4hQDDrDs=",
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -3722,17 +3715,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.18.2.tgz",
-      "integrity": "sha1-P6vggpbpMMeWwZ48UWl5OGup/Vk=",
-      "license": "MIT",
+      "version": "4.19.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.19.2.tgz",
+      "integrity": "sha1-4lQ3gno6p/KoJ7yBcbu7Zko1ZGU=",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3955,16 +3947,15 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha1-/i8+8mkK/OfoLtC0TbCBZbIHEjo=",
+      "version": "1.15.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -4431,7 +4422,6 @@
       "version": "0.4.24",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
-      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -5691,8 +5681,7 @@
     "node_modules/js-stringify": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
-      "license": "MIT"
+      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6554,12 +6543,11 @@
       }
     },
     "node_modules/notifications-node-client": {
-      "version": "7.0.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/notifications-node-client/-/notifications-node-client-7.0.3.tgz",
-      "integrity": "sha1-h1Jlu12t2xwBpMofsboMqlRYcb4=",
-      "license": "MIT",
+      "version": "7.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/notifications-node-client/-/notifications-node-client-7.0.6.tgz",
+      "integrity": "sha1-XCPprdWpr3Yl9vnTKOj5XC3r5wU=",
       "dependencies": {
-        "axios": "^0.25.0",
+        "axios": "^1.6.1",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -6568,12 +6556,26 @@
       }
     },
     "node_modules/notifications-node-client/node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha1-NJz7sxMxqbRFMZB5F2Co01sJPgo=",
-      "license": "MIT",
+      "version": "1.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha1-tiXbinBR++phw1o8uzodqnucdiE=",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/notifications-node-client/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/npm-run-path": {
@@ -7081,6 +7083,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/psl/-/psl-1.9.0.tgz",
@@ -7088,12 +7095,11 @@
       "license": "MIT"
     },
     "node_modules/pug": {
-      "version": "3.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug/-/pug-3.0.2.tgz",
-      "integrity": "sha1-81xxBzQ0VOQ7wnrg/3bHMbeOpTU=",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug/-/pug-3.0.3.tgz",
+      "integrity": "sha1-4YMkoxTNAiiDseA3K4rzoamfdZc=",
       "dependencies": {
-        "pug-code-gen": "^3.0.2",
+        "pug-code-gen": "^3.0.3",
         "pug-filters": "^4.0.0",
         "pug-lexer": "^5.0.1",
         "pug-linker": "^4.0.0",
@@ -7107,7 +7113,6 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-attrs/-/pug-attrs-3.0.0.tgz",
       "integrity": "sha1-sQRR4DSBZeMfrRzCPr3dncc0fEE=",
-      "license": "MIT",
       "dependencies": {
         "constantinople": "^4.0.1",
         "js-stringify": "^1.0.2",
@@ -7115,26 +7120,24 @@
       }
     },
     "node_modules/pug-code-gen": {
-      "version": "3.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
-      "integrity": "sha1-rRkPSUMTO/GGtguA3kgxAOEy4s4=",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
+      "integrity": "sha1-WBMxeMtCP+Fxauzhwdo5KnUlFSA=",
       "dependencies": {
         "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
         "js-stringify": "^1.0.2",
         "pug-attrs": "^3.0.0",
-        "pug-error": "^2.0.0",
-        "pug-runtime": "^3.0.0",
+        "pug-error": "^2.1.0",
+        "pug-runtime": "^3.0.1",
         "void-elements": "^3.1.0",
         "with": "^7.0.0"
       }
     },
     "node_modules/pug-error": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-error/-/pug-error-2.0.0.tgz",
-      "integrity": "sha1-XGIXPLCcNN4qLOBPF7it/sdNjKU=",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-error/-/pug-error-2.1.0.tgz",
+      "integrity": "sha1-F+o3tYe2RD1LjxSDdOwntUtAblU="
     },
     "node_modules/pug-filters": {
       "version": "4.0.0",
@@ -7193,8 +7196,7 @@
     "node_modules/pug-runtime": {
       "version": "3.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-runtime/-/pug-runtime-3.0.1.tgz",
-      "integrity": "sha1-9jaXYgRyPzWoxfb61qzaKhkbg9c=",
-      "license": "MIT"
+      "integrity": "sha1-9jaXYgRyPzWoxfb61qzaKhkbg9c="
     },
     "node_modules/pug-strip-comments": {
       "version": "2.0.0",
@@ -7290,10 +7292,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha1-/hsWKLGBtwAhXl/UI4n5i3E5KFc=",
-      "license": "MIT",
+      "version": "2.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha1-mf69g7kOCJdQh+jx+UGaFJNmtoo=",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -8806,7 +8807,6 @@
       "version": "3.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8875,7 +8875,6 @@
       "version": "7.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/with/-/with-7.0.2.tgz",
       "integrity": "sha1-zO461ULSVTinp6gKrSErmChJW6w=",
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.9.6",
         "@babel/types": "^7.9.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "lodash": "^4.17.21",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.dao": "4.2.0",
-        "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.0.0",
-        "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.11.6",
+        "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
+        "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
         "markdown": "^0.5.0",
         "notifications-node-client": "^7.0.0",
         "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ejs": "^3.1.6",
     "lodash": "^4.17.21",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
-    "login.dfe.dao": "github:DFE-Digital/login.dfe.dao#v4.2.12",
+    "login.dfe.dao": "4.2.12",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
     "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
     "marked": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "ejs": "^3.1.6",
     "lodash": "^4.17.21",
     "login.dfe.dao": "4.2.0",
-    "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
-    "login.dfe.kue": "git+https://github.com/DFE-Digital/login.dfe.kue.git#v0.11.6",
-    "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
+    "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.0.0",
+    "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.11.6",
+    "login.dfe.request-promise-retry": "github:DFE-Digital/login.dfe.request-promise-retry#v3.0.0",
     "markdown": "^0.5.0",
     "notifications-node-client": "^7.0.0",
     "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ejs": "^3.1.6",
     "lodash": "^4.17.21",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
-    "login.dfe.dao": "4.2.0",
+    "login.dfe.dao": "github:DFE-Digital/login.dfe.dao#v4.2.12",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
     "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
     "marked": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.notification.jobs",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "Job handlers for notifications",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "login.dfe.dao": "4.2.0",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
     "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
-    "markdown": "^0.5.0",
+    "marked": "^12.0.2",
     "notifications-node-client": "^7.0.0",
     "uuid": "^8.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "aws-sdk": "^2.279.1",
     "ejs": "^3.1.6",
     "lodash": "^4.17.21",
+    "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.dao": "4.2.0",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.0.0",
     "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.11.6",
-    "login.dfe.request-promise-retry": "github:DFE-Digital/login.dfe.request-promise-retry#v3.0.0",
     "markdown": "^0.5.0",
     "notifications-node-client": "^7.0.0",
     "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "lodash": "^4.17.21",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.dao": "4.2.0",
-    "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.0.0",
-    "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.11.6",
+    "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
+    "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
     "markdown": "^0.5.0",
     "notifications-node-client": "^7.0.0",
     "uuid": "^8.3.2"

--- a/test/handlers/invitationTests/newUserInvitationV2.test.js
+++ b/test/handlers/invitationTests/newUserInvitationV2.test.js
@@ -88,18 +88,18 @@ describe('when sending v2 user invitation', () => {
 
   it('then it should add html version of override body if one is present', async () => {
     data.overrides = {
-      body: '#This is a test\n\nIt should *ignore* the formatting in _here_',
+      body: '# This is a test\n\nIt should *ignore* the formatting in _here_',
     };
 
     await handler.processor(data);
 
     expect(send.mock.calls).toHaveLength(1);
-    expect(send.mock.calls[0][2].overrides.htmlBody).toBe('<h1>This is a test</h1>\n\n<p>It should <em>ignore</em> the formatting in <em>here</em></p>');
+    expect(send.mock.calls[0][2].overrides.htmlBody).toBe('<h1>This is a test</h1>\n<p>It should <em>ignore</em> the formatting in <em>here</em></p>');
   });
 
   it('then it should add a plain text version of override body if one is present', async () => {
     data.overrides = {
-      body: '#This is a test\n\nIt should *ignore* the formatting in _here_',
+      body: '# This is a test\n\nIt should *ignore* the formatting in _here_',
     };
 
     await handler.processor(data);


### PR DESCRIPTION
At the time of writing the `npm audit` command reports the following on the develop branch:

> 21 vulnerabilities (1 low, 12 moderate, 8 high)

After this work the `npm audit` command now reports the following on this branch:

> found 0 vulnerabilities

### Overview of work undertaken

1. Automatically fix vulnerable dependencies with the `npm audit fix` command.
2. Update `login.dfe.*` dependencies from `git+https//` to `github:DFE-Digital`.
3. Remove `login.dfe.request-promise-retry` and use `login.dfe.async-retry`.
4. Replace `markdown` with `marked` and maintain close compatibility in template formatting.
5. Reference `login.dfe.dao` by package and no artefact. 
