### PR TITLE
[DSI-7220] Add Entra invitation email templates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "extends": "airbnb-base",
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
   "rules": {
     "no-empty": ["error", { "allowEmptyCatch": true }],
     "prefer-rest-params": "off",

--- a/lib/handlers/invite/newUserInvitationV2.js
+++ b/lib/handlers/invite/newUserInvitationV2.js
@@ -46,17 +46,21 @@ const process = async (config, logger, data) => {
       overrides.textBody = convertMarkdownToText(overrides.body).trim();
       overrides.htmlBody = convertMarkdownToHtml(overrides.body);
     }
-    var template = data.isMigrationInvite ? 'migrationv2' : 'invitation';
-      if(data.isChaserEmail)
-      {
+
+    let template;
+    if (config.entra?.enableEntraSignIn === true) {
+      template = 'invitation-entra-registration';
+    } else {
+      template = data.isMigrationInvite ? 'migrationv2' : 'invitation';
+      if (data.isChaserEmail) {
         template = 'invitation-chaser-email';
         subject = `You must take action to keep accessing the ${serviceName}`;
       }
-      if(data.isServiceActivationChaserEmail)
-      {
+      if (data.isServiceActivationChaserEmail) {
         template = 'invitation-serviceactivation-chaser-email';
         subject = `You must take action to keep accessing the ${serviceName}`;
       }
+    }
       let bccEmail = 'NoReply.PireanMigration@education.gov.uk';
       if(process && process.env && process.env.INV_BCC_EMAIL){
         bccEmail = process.env.INV_BCC_EMAIL;

--- a/lib/handlers/invite/newUserInvitationV2.js
+++ b/lib/handlers/invite/newUserInvitationV2.js
@@ -1,43 +1,40 @@
-const { getEmailAdapter } = require('./../../infrastructure/email');
-const {marked} = require('marked')
+const { marked } = require('marked');
+const { getEmailAdapter } = require('../../infrastructure/email');
 
-
-//Its possible that 'marked' will HTML encode strings. For example, the word [You've] will be
-//encoded as [You&#39;ve]. decodeHtmlEntities attempts to resolve this.
+// Its possible that 'marked' will HTML encode strings. For example, the word [You've] will be
+// encoded as [You&#39;ve]. decodeHtmlEntities attempts to resolve this.
 const decodeHtmlEntities = (str) => {
   const htmlEntities = {
-      '&amp;': '&',
-      '&lt;': '<',
-      '&gt;': '>',
-      '&quot;': '"',
-      '&#39;': "'",
-      '&#x27;': "'",
-      '&#x2F;': '/',
-      '&#x5C;': '\\',
-      '&#96;': '`',
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#39;': "'",
+    '&#x27;': "'",
+    '&#x2F;': '/',
+    '&#x5C;': '\\',
+    '&#96;': '`',
   };
 
   return str.replace(/&[#A-Za-z0-9]+;/g, (entity) => htmlEntities[entity] || entity);
 };
 
-const convertMarkdownToHtml = (content) => {
-  return marked.parse(content).trim();
-};
+const convertMarkdownToHtml = (content) => marked.parse(content).trim();
 
 const convertMarkdownToText = (content) => {
   const html = convertMarkdownToHtml(content);
-  return decodeHtmlEntities(html.replace(/<[^>]+?>/g, ""));
+  return decodeHtmlEntities(html.replace(/<[^>]+?>/g, ''));
 };
 
 const process = async (config, logger, data) => {
   try {
-    const serviceName = data.serviceName;
+    const { serviceName } = data;
     const source = data.source || undefined;
     const requiresDigipass = data.requiresDigipass || false;
     let subject = data.selfInvoked
       ? `${data.code} is your DfE Sign-in verification code`
-      : `You’ve been invited to join DfE Sign-in`;
-    const overrides = Object.assign({}, data.overrides || {});
+      : 'You’ve been invited to join DfE Sign-in';
+    const overrides = { ...data.overrides || {} };
 
     if (overrides.subject) {
       subject = data.overrides.subject;
@@ -61,10 +58,10 @@ const process = async (config, logger, data) => {
         subject = `You must take action to keep accessing the ${serviceName}`;
       }
     }
-      let bccEmail = 'NoReply.PireanMigration@education.gov.uk';
-      if(process && process.env && process.env.INV_BCC_EMAIL){
-        bccEmail = process.env.INV_BCC_EMAIL;
-      }
+    let bccEmail = 'NoReply.PireanMigration@education.gov.uk';
+    if (process && process.env && process.env.INV_BCC_EMAIL) {
+      bccEmail = process.env.INV_BCC_EMAIL;
+    }
     const email = getEmailAdapter(config, logger);
     await email.send(data.email, template, {
       firstName: data.firstName,
@@ -77,30 +74,26 @@ const process = async (config, logger, data) => {
       helpUrl: `${config.notifications.helpUrl}/contact-us`,
       getmoreinfoUrl: `${config.notifications.helpUrl}/moving-to-DfE-Sign-in`,
       feConnectUrl: `${config.notifications.feConnectUrl}` || null,
-      overrides: overrides,
+      overrides,
       email: data.email,
       approverEmail: data.approverEmail,
       orgName: data.orgName,
       isApprover: data.isApprover,
-      source: source,
+      source,
     }, subject, bccEmail);
-
   } catch (e) {
     console.log(`bcc-email invitation_v2 :${JSON.stringify(e)}`);
     logger.error(`Failed to process and send the email for type invitation_v2- ${JSON.stringify(e)}`);
     throw new Error(`Failed to process and send the email for type invitation_v2 - ${JSON.stringify(e)}`);
   }
-
 };
 
-const getHandler = (config, logger) => {
-  return {
-    type: 'invitation_v2',
-    processor: async (data) => {
-      await process(config, logger, data);
-    }
-  };
-};
+const getHandler = (config, logger) => ({
+  type: 'invitation_v2',
+  processor: async (data) => {
+    await process(config, logger, data);
+  },
+});
 
 module.exports = {
   getHandler,

--- a/lib/infrastructure/templates/renderTemplates/invitation-entra-registration/email/html.ejs
+++ b/lib/infrastructure/templates/renderTemplates/invitation-entra-registration/email/html.ejs
@@ -1,0 +1,145 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org=
+/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta content="telephone=no" name="format-detection" />
+    <meta name="viewport" content="width=device-width" />
+
+    <title>GOVUK</title>
+
+    <style>
+        @media only screen and (min-device-width: 581px) {
+            .content {
+                width: 580px !important;
+            }
+        }
+        body { margin:0 !important; }
+        div[style*="margin: 16px 0"] { margin:0 !important; }
+        .button-link {
+            color: #FFFFFF !important;
+            border-bottom: 3px solid #000000;
+            background-color:#00703c; 
+            position:relative;
+            display:-moz-inline-stack;display:inline-block;
+            padding:.526315em .789473em .263157em;
+            text-decoration:none;
+        }
+        .button-link a[href]{
+            color: #FFFFFF !important;
+        }
+        .button-link:link, .button-link:focus:link, .button-link:hover, .button-link:focus, .button-link:visited{
+            color:#fff;
+        }
+        .foot-content{
+            margin-top: 20px;
+        }
+        .foot-content p{
+            margin-top: 5px;
+            margin-bottom: 0px;
+        }
+    </style>
+
+</head>
+<body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c;">
+<table role="presentation" width="100%" style="min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+        <td width="100%" height="53" bgcolor="#0b0c0c">
+            <table role="presentation" width="100%" style="max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
+                <tr>
+                    <td width="70" bgcolor="#0b0c0c" valign="middle">
+                        <a href="https://www.gov.uk" style="text-decoration: none;">
+                            <img src="https://static.notifications.service.gov.uk/images/gov.uk_logotype_crown.png"
+                                 alt="" height="32" border="0" style="margin-top: 4px; margin-left: 10px;"></a>
+                    </td>
+                    <td width="100%" bgcolor="#0b0c0c" valign="middle" align="left">
+                      <span style="padding-left: 5px;"><a href="https://www.gov.uk" style="
+                          font-family: Helvetica, Arial, sans-serif;
+                          font-size: 28px;
+                          line-height: 1.315789474;
+                          font-weight: 700;
+                          color: #ffffff;
+                          text-decoration: none;">GOV.UK</a></span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<table
+        role="presentation"
+        class="content"
+        align="center"
+        cellpadding="0"
+        cellspacing="0"
+        border="0"
+        style="max-width: 580px; width: 100% !important;"
+        width="100%"
+>
+    <tr>
+        <td width="10" height="10" valign="middle"></td>
+        <td>
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                    <td bgcolor="#005EA5" width="100%" height="10"></td>
+                </tr>
+            </table>
+        </td>
+        <td width="10" valign="middle" height="10"></td>
+    </tr>
+</table>
+<table
+        role="presentation"
+        class="content"
+        align="center"
+        cellpadding="0"
+        cellspacing="0"
+        border="0"
+        style="max-width: 580px; width: 100% !important;"
+        width="100%"
+>
+    <tr>
+        <td height="30">&nbsp;</td>
+    </tr>
+    <tr>
+        <td width="10" valign="middle">&nbsp;</td>
+        <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
+
+            <p>Dear <%=firstName%> <%=lastName%>,</p>
+
+            <% if (overrides && overrides.htmlBody) { %>
+                <%- overrides.htmlBody %>
+            <% } %>
+
+            <p>Your email address <b><%=email%></b> can now be used to create a DfE Sign-in account.</p>
+
+            <%if(isApprover) { %>
+                <p>Your account will have approver status. As an approver, you will be able to manage other users at your organisation and add services to their accounts.</p>
+            <% } %>
+
+            <p>Click the button below or visit the <a href="<%=returnUrl%>">registration page</a> to create your account.</p>
+            
+            <a class="button-link" href="<%=returnUrl%>">Create account</a>
+
+            <div class="foot-content">
+                <p>Kind regards,</p>
+
+                <p>The Department for Education Sign-in Team</p>
+
+                <p> <b>Need support? </b><a href="<%=helpUrl%>" style="color: #1d70b8 !important;">Contact us for further help</a></p>
+            </div>
+
+            <div class="foot-content">
+            <p>This is an automatically generated email. Do not reply.</p>
+            <p>Received this email in error? No action needed.</p>
+            </div>
+        </td>
+        <td width="10" valign="middle">&nbsp;</td>
+    </tr>
+    <tr>
+        <td height="30">&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>
+

--- a/lib/infrastructure/templates/renderTemplates/invitation-entra-registration/email/text.ejs
+++ b/lib/infrastructure/templates/renderTemplates/invitation-entra-registration/email/text.ejs
@@ -1,0 +1,23 @@
+Dear <%=firstName%> <%=lastName%>,
+
+<% if (overrides && overrides.textBody) { %>
+<%- overrides.textBody %>
+<% } %>
+
+Your email address <%=email%> can now be used to create a DfE Sign-in account.
+
+<%if(isApprover) { %>
+Your account will have approver status. As an approver, you will be able to manage other users at your organisation and add services to their accounts.
+<% } %>
+
+To create your account, please follow the link below:
+<%=returnUrl%>
+
+Kind regards,
+
+The Department for Education Sign-in Team
+
+Need support? Contact us for further help <%=helpUrl%>
+
+This is an automatically generated email. Do not reply.
+Received this email in error? No action needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2004,9 +2004,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha1-tiXbinBR++phw1o8uzodqnucdiE=",
+      "version": "1.7.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha1-L1VClvmJKnKsjY5MW3nBSpHQpH8=",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -2217,9 +2218,10 @@
       "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha1-b+sOIcRyTQbef/ONo22tT1enR/0=",
+      "version": "1.20.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha1-GVNDEiHG+1zWPEs21T+rCSjlSMY=",
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -2229,7 +2231,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -2899,9 +2901,10 @@
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3057,7 +3060,8 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3338,6 +3342,7 @@
       "version": "1.8.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3408,36 +3413,37 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.19.2.tgz",
-      "integrity": "sha1-4lQ3gno6p/KoJ7yBcbu7Zko1ZGU=",
+      "version": "4.21.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.21.0.tgz",
+      "integrity": "sha1-1Xy3BtSWI9SsJ4M/HLxGa2aOuRU=",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -3552,12 +3558,13 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha1-fSP+VzGyB7RkDk/NAK7B+SB6ezI=",
+      "version": "1.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha1-DFdfHR0yTd0do1rX7OPffRkIgBk=",
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -3572,6 +3579,7 @@
       "version": "2.6.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3579,7 +3587,8 @@
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -3666,6 +3675,7 @@
       "version": "0.5.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5545,9 +5555,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha1-2AMZpl88eTU1Hlz9rI+TGFBNvtU=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5564,10 +5578,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha1-M+gZDZ/kdKmJVSX1YY7uE21GwuU=",
+      "version": "4.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -5580,6 +5595,7 @@
       "version": "1.6.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime/-/mime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -6078,6 +6094,7 @@
       "version": "1.3.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6112,9 +6129,10 @@
       "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "version": "0.1.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha1-Z+kQjFwFUbnlMmBkOH3kdjxNX4s=",
+      "license": "MIT"
     },
     "node_modules/pg-connection-string": {
       "version": "2.6.4",
@@ -6438,11 +6456,12 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha1-/Q2WNEb3pl4TZ+AavYVClFPww3o=",
+      "version": "6.13.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha1-bKO9WEOffiRWVXmJl3h7DYilGQY=",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -6482,6 +6501,7 @@
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6839,9 +6859,10 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/send/-/send-0.18.0.tgz",
-      "integrity": "sha1-ZwFnzGVLBfWqSnZ/kRO7NxvHBr4=",
+      "version": "0.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/send/-/send-0.19.0.tgz",
+      "integrity": "sha1-u8WjiMjqbASJZwSdvqwOSj8J1/g=",
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -6865,6 +6886,7 @@
       "version": "2.6.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -6872,12 +6894,23 @@
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/sequelize": {
       "version": "6.37.3",
@@ -6970,14 +7003,15 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha1-+q7wjP/goaYvYMrQxOUTz/CslUA=",
+      "version": "1.16.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha1-tqU0PaR/a90mc4SL9FdUlB6AMpY=",
+      "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2563,9 +2563,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha1-J5iwSwcbDsv/DbtipQWo76ThkFE=",
+      "version": "0.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha1-L3PEIULV1c9xMQp0/ErmFnDl28k=",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3413,17 +3413,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.21.0.tgz",
-      "integrity": "sha1-1Xy3BtSWI9SsJ4M/HLxGa2aOuRU=",
-      "license": "MIT",
+      "version": "4.21.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.21.1.tgz",
+      "integrity": "sha1-na5d2oMvFrTuyUGk5EqonsSBsoE=",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.notification.jobs",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.notification.jobs",
-      "version": "6.3.3",
+      "version": "6.3.4",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.279.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.notification.jobs",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "description": "Job handlers for notifications",
   "main": "lib/index.js",
   "scripts": {

--- a/test/handlers/invitationTests/newUserInvitationV2.test.js
+++ b/test/handlers/invitationTests/newUserInvitationV2.test.js
@@ -54,6 +54,16 @@ describe('when sending v2 user invitation', () => {
     expect(send.mock.calls[0][1]).toBe('invitation');
   });
 
+  it('then it should send email using `invitation-entra-registration` template if `enableEntraSignIn` feature flag is enabled ', async () => {
+    config.entra = {
+      enableEntraSignIn: true,
+    };
+    await handler.processor(data);
+
+    expect(send.mock.calls).toHaveLength(1);
+    expect(send.mock.calls[0][1]).toBe('invitation-entra-registration');
+  });
+
   it('then it should send email to email address in data', async () => {
     await handler.processor(data);
 


### PR DESCRIPTION
## Summary
**Jira ticket:** https://dfe-secureaccess.atlassian.net/browse/DSI-7220
## Changes
- create invitation email templates for new user registrations using Entra
- update the invitation email handler to utilise the new templates when the `enableEntraSignIn` Entra  feature flag is activated
- fix all linting issues in `newUserInvitationV2.js`
- fix vulnerabilities using `npm audit fix` command
- bump package version to `6.3.4`

## Related PRs:

- https://github.com/DFE-Digital/login.dfe.jobs/pull/265
- https://github.com/DFE-Digital/login.dfe.dsi-config/pull/16